### PR TITLE
Implement EditContent page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "entando-cms",
+  "name": "@entando/cms",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -4327,8 +4327,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -4346,13 +4345,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -4365,18 +4362,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -4479,8 +4473,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -4490,7 +4483,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -4503,20 +4495,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -4533,7 +4522,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -4606,8 +4594,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -4617,7 +4604,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -4693,8 +4679,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -4724,7 +4709,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -4742,7 +4726,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -4781,13 +4764,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -8175,8 +8156,7 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
@@ -8197,8 +8177,7 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",

--- a/src/api/__tests__/editContent.test.js
+++ b/src/api/__tests__/editContent.test.js
@@ -49,7 +49,7 @@ describe('api/editContent', () => {
     it('returns a promise for getContent', () => {
       const response = getContent();
       expect(makeRequest).toHaveBeenCalledWith({
-        uri: '/api/plugins/cms/contents/',
+        uri: '/api/plugins/cms/contents',
         method: 'GET',
         mockResponse: GET_CONTENT_RESPONSE_OK,
         contentType: 'application/json',

--- a/src/api/editContent.js
+++ b/src/api/editContent.js
@@ -12,7 +12,8 @@ const getCategoriesPath = '/api/categories';
 const postAddContentPath = '/api/plugins/cms/contents/';
 
 export const getContent = (params = '') => makeRequest({
-  uri: `${getContentPath}/${params}`,
+  // @TODO unable to fetch single content due to bug EN6-103, change path when issue is resolved
+  uri: `${getContentPath}${params}`,
   method: METHODS.GET,
   contentType: 'application/json',
   mockResponse: GET_CONTENT_RESPONSE_OK,

--- a/src/state/categories/selectors.js
+++ b/src/state/categories/selectors.js
@@ -12,6 +12,7 @@ export const getSelected = state => get(state.categories, 'selected', {});
 export const getSelectedRefs = state => get(state.categories, 'selected.references', {});
 export const getReferenceKeyList = state => get(state.categories, 'selected.referenceKeyList', []);
 export const getReferenceMap = state => get(state.categories, 'selected.referenceMap', {});
+export const getJoinedCategoriesCodes = state => state.editContent.joinedCategories;
 
 const CATEGORY_STATUS_DEFAULTS = {
   expanded: false,
@@ -108,4 +109,9 @@ export const getAllCategories = createSelector(
     children: categoryChildren[categoryCode],
     isEmpty: !(categoryChildren[categoryCode] && categoryChildren[categoryCode].length),
   })),
+);
+
+export const getJoinedCategoriesByCodes = createSelector(
+  [getAllCategories, getJoinedCategoriesCodes],
+  (categories, codes) => categories.filter(c => codes.includes(c.code)),
 );

--- a/src/state/edit-content/__tests__/actions.test.js
+++ b/src/state/edit-content/__tests__/actions.test.js
@@ -33,7 +33,7 @@ const SET_GROUPS_PARAMS = {
 };
 
 jest.mock('api/editContent', () => ({
-  getContent: jest.fn(mockApi({ payload: ['a', 'b'] })),
+  getContent: jest.fn(mockApi({ payload: { content: { categories: ['home'] } } })),
   getGroups: jest.fn(mockApi({ payload: ['a', 'b'] })),
   postAddContent: jest.fn(mockApi({ payload: { a: 1, contentType: 'YO' } })),
 }));
@@ -53,7 +53,6 @@ it('test setGroups action', () => {
 describe('editContent thunks', () => {
   let store;
   beforeEach(() => {
-    jest.unmock('api/editContent');
     store = createMockStore({ editContent: { content: {} } });
   });
   it('fetchContent', (done) => {
@@ -62,7 +61,7 @@ describe('editContent thunks', () => {
       .then(() => {
         const actions = store.getActions();
         expect(actions[0]).toHaveProperty('type', SET_CONTENT_ENTRY);
-        expect(actions[0].payload.content).toEqual(['a', 'b']);
+        expect(actions[0].payload.content).toEqual([]);
         done();
       })
       .catch(done.fail);

--- a/src/state/edit-content/__tests__/reducer.test.js
+++ b/src/state/edit-content/__tests__/reducer.test.js
@@ -4,6 +4,7 @@ import {
   setWorkMode,
   setOwnerGroupDisable,
   setContentEntry,
+  setJoinedCategories,
 } from 'state/edit-content/actions';
 import { WORK_MODE_ADD } from 'state/edit-content/types';
 import { onJoinCategory, onUnjoinCategory } from 'state/categories/actions';
@@ -29,6 +30,16 @@ describe('state/edit-content/reducer', () => {
       expect(state.groups).toHaveLength(0);
     });
   });
+  describe('after action setJoinedCategories', () => {
+    let state;
+    beforeEach(() => {
+      state = reducer({ joinedCategories: [] }, setJoinedCategories(['home']));
+    });
+    it('joined categories should be changed', () => {
+      expect(state).toHaveProperty('joinedCategories');
+      expect(state.joinedCategories).toEqual(['home']);
+    });
+  });
   describe('after action SET_WORK_MODE', () => {
     let state;
     beforeEach(() => {
@@ -44,7 +55,7 @@ describe('state/edit-content/reducer', () => {
     beforeEach(() => {
       state = reducer({ ownerGroupDisabled: false }, setOwnerGroupDisable(true));
     });
-    it('owner group should become disabld', () => {
+    it('owner group should become disabled', () => {
       expect(state).toHaveProperty('ownerGroupDisabled');
       expect(state.ownerGroupDisabled).toEqual({ disabled: true });
     });
@@ -56,38 +67,38 @@ describe('state/edit-content/reducer', () => {
     });
     it('Content should be changed', () => {
       expect(state).toHaveProperty('content');
-      expect(state.content).toEqual({ content });
+      expect(state.content).toEqual(content);
     });
   });
   describe('after action JOIN_CATEGORY', () => {
     let state;
     beforeEach(() => {
-      state = reducer({ joinedCategories: [{ code: 'OFFICE' }] }, onJoinCategory({ code: 'NEWS' }));
+      state = reducer({ joinedCategories: ['OFFICE'] }, onJoinCategory('NEWS'));
     });
     it('Joined categories array should be changed', () => {
       expect(state).toHaveProperty('joinedCategories');
-      expect(state.joinedCategories).toEqual([{ code: 'OFFICE' }, { code: 'NEWS' }]);
+      expect(state.joinedCategories).toEqual(['OFFICE', 'NEWS']);
     });
     it('Should not add already added category', () => {
       state = reducer(
-        { joinedCategories: [{ code: 'OFFICE' }] },
-        onJoinCategory({ code: 'OFFICE' }),
+        { joinedCategories: ['OFFICE'] },
+        onJoinCategory('OFFICE'),
       );
       expect(state).toHaveProperty('joinedCategories');
-      expect(state.joinedCategories).toEqual([{ code: 'OFFICE' }]);
+      expect(state.joinedCategories).toEqual(['OFFICE']);
     });
   });
   describe('after action UNJOIN_CATEGORY', () => {
     let state;
     beforeEach(() => {
       state = reducer(
-        { joinedCategories: [{ code: 'NEWS' }, { code: 'OFFICE' }] },
+        { joinedCategories: ['NEWS', 'OFFICE'] },
         onUnjoinCategory('NEWS'),
       );
     });
     it('Joined categories array should be changed', () => {
       expect(state).toHaveProperty('joinedCategories');
-      expect(state.joinedCategories).toEqual([{ code: 'OFFICE' }]);
+      expect(state.joinedCategories).toEqual(['OFFICE']);
     });
   });
 });

--- a/src/state/edit-content/reducer.js
+++ b/src/state/edit-content/reducer.js
@@ -6,6 +6,7 @@ import {
   SET_GROUPS,
   JOIN_CATEGORY,
   UNJOIN_CATEGORY,
+  SET_JOINED_CATEGORIES,
 } from 'state/edit-content/types';
 
 const defaultState = {
@@ -14,15 +15,8 @@ const defaultState = {
   },
   language: 'en',
   workMode: WORK_MODE_ADD,
-  content: {
-    contentType: 'NEWS',
-    version: '0.0',
-  },
-  contentType: 'NEWS',
-  groups: [
-    { code: 'adminstrators', name: 'Administrators' },
-    { code: 'freeAccess', name: 'Free Access' },
-  ],
+  contentType: '',
+  groups: [],
   joinedCategories: [],
 };
 
@@ -38,21 +32,22 @@ const reducer = (state = defaultState, action = {}) => {
         ...state,
         workMode: action.payload,
       };
-    case SET_CONTENT_ENTRY:
-      return {
-        ...state,
-        content: action.payload,
-      };
     case SET_GROUPS:
       return {
         ...state,
         groups: action.payload.groups || [],
       };
+    case SET_JOINED_CATEGORIES: {
+      return {
+        ...state,
+        joinedCategories: action.payload.joinedCategories || [],
+      };
+    }
     case JOIN_CATEGORY: {
       const { category: newCategory } = action.payload;
       const currentJoinedCategories = state.joinedCategories;
       const alreadyAdded = currentJoinedCategories.filter(
-        category => category.code === newCategory.code,
+        category => category === newCategory,
       ).length > 0;
       if (!alreadyAdded) {
         return {
@@ -66,7 +61,14 @@ const reducer = (state = defaultState, action = {}) => {
       const { categoryCode } = action.payload;
       return {
         ...state,
-        joinedCategories: state.joinedCategories.filter(category => category.code !== categoryCode),
+        joinedCategories: state.joinedCategories.filter(category => category !== categoryCode),
+      };
+    }
+    case SET_CONTENT_ENTRY: {
+      const { content } = action.payload;
+      return {
+        ...state,
+        content,
       };
     }
     default:

--- a/src/state/edit-content/types.js
+++ b/src/state/edit-content/types.js
@@ -7,3 +7,4 @@ export const SET_GROUPS = 'edit-content/set-groups';
 export const JOIN_CATEGORY = 'edit-content/join-category';
 export const UNJOIN_CATEGORY = 'edit-content/unjoin-category';
 export const GET_LANGUAGE = 'edit-content/get-language';
+export const SET_JOINED_CATEGORIES = 'edit-content/set-joined-categories';

--- a/src/testutils/mocks/editContent.js
+++ b/src/testutils/mocks/editContent.js
@@ -2,7 +2,8 @@ export const EDIT_CONTENT_OPENED_OK = {
   ownerGroupDisabled: false,
   currentUser: undefined,
   language: 'en',
-  workMode: 'work-mode-add',
+  workMode: 'work-mode-edit',
+  contentId: 1,
   content: {
     contentType: 'NEWS',
     version: '0.0',
@@ -11,6 +12,20 @@ export const EDIT_CONTENT_OPENED_OK = {
     { code: 'adminstrators', name: 'Administrators' },
     { code: 'freeAccess', name: 'Free Access' },
   ],
+  selectedCategories: undefined,
+  selectedJoinGroups: undefined,
+};
+
+export const ADD_CONTENT_OPENED_OK = {
+  ownerGroupDisabled: false,
+  currentUser: undefined,
+  language: 'en',
+  workMode: 'work-mode-add',
+  groups: [
+    { code: 'adminstrators', name: 'Administrators' },
+    { code: 'freeAccess', name: 'Free Access' },
+  ],
+  contentType: undefined,
   selectedCategories: undefined,
   selectedJoinGroups: undefined,
 };

--- a/src/ui/App.js
+++ b/src/ui/App.js
@@ -7,6 +7,7 @@ import {
   ROUTE_CMS_CONTENTMODEL_LIST,
   ROUTE_CMS_CONTENTMODEL_ADD,
   ROUTE_CMS_ADD_CONTENT,
+  ROUTE_CMS_EDIT_CONTENT,
   ROUTE_CMS_CONTENTMODEL_EDIT,
 } from 'app-init/routes';
 
@@ -14,6 +15,7 @@ import IntlProviderContainer from 'ui/locale/IntlProviderContainer';
 import ContentModelListPage from 'ui/content-model/ContentModelListPage';
 import AddContentModelPage from 'ui/content-model/AddContentModelPage';
 import AddContentPage from 'ui/add-content/AddContentPage';
+import EditContentPage from 'ui/edit-content/EditContentPage';
 import EditContentModelPage from 'ui/content-model/EditContentModelPage';
 
 import ToastsContainer from 'ui/toast/ToastsContainer';
@@ -34,6 +36,10 @@ const routesDir = [
   {
     path: ROUTE_CMS_CONTENTMODEL_EDIT,
     component: EditContentModelPage,
+  },
+  {
+    path: ROUTE_CMS_EDIT_CONTENT,
+    component: EditContentPage,
   },
 ];
 

--- a/src/ui/add-content/AddContentFormContainer.js
+++ b/src/ui/add-content/AddContentFormContainer.js
@@ -41,7 +41,7 @@ export const mapStateToProps = state => ({
   currentUser: getCurrentUser(state),
   ownerGroupDisabled: getOwnerGroupDisabled(state),
   selectedJoinGroups: formValueSelector('editcontentform')(state, 'joinGroups'),
-  selectedCategories: formValueSelector('editcontentform')(state, 'contentCategory'),
+  selectedCategories: formValueSelector('editcontentform')(state, 'contentCategories'),
 });
 
 export const mapDispatchToProps = (dispatch, { intl, history }) => ({

--- a/src/ui/add-content/__tests__/AddContentFormContainer.test.js
+++ b/src/ui/add-content/__tests__/AddContentFormContainer.test.js
@@ -1,7 +1,7 @@
 import { configEnzymeAdapter } from 'testutils/helpers';
 
-import { mapStateToProps, mapDispatchToProps } from 'ui/edit-content/EditContentFormContainer';
-import { EDIT_CONTENT_OPENED_OK } from 'testutils/mocks/editContent';
+import { mapStateToProps, mapDispatchToProps } from 'ui/add-content/AddContentFormContainer';
+import { ADD_CONTENT_OPENED_OK } from 'testutils/mocks/editContent';
 
 const TEST_STATE = {
   editContent: {
@@ -9,7 +9,7 @@ const TEST_STATE = {
       disabled: false,
     },
     language: 'en',
-    workMode: 'work-mode-edit',
+    workMode: 'work-mode-add',
     content: {
       contentType: 'NEWS',
       version: '0.0',
@@ -23,15 +23,11 @@ const TEST_STATE = {
   },
 };
 
-const TEST_OWN_PROPS = {
-  match: { params: { id: 1 } },
-};
-
 configEnzymeAdapter();
 
-describe('EditContentFormContainer connection to redux', () => {
-  it('maps editContent properties from state to EditContentForm', () => {
-    expect(mapStateToProps(TEST_STATE, TEST_OWN_PROPS)).toEqual(EDIT_CONTENT_OPENED_OK);
+describe('AddContentFormContainer connection to redux', () => {
+  it('maps editContent properties from state to AddContentForm', () => {
+    expect(mapStateToProps(TEST_STATE)).toEqual(ADD_CONTENT_OPENED_OK);
   });
 
   it('verify that onDidMount and onSetOwnerGroupDisable are defined and called in mapDispatchToProps', () => {

--- a/src/ui/add-content/__tests__/AddContentPage.test.js
+++ b/src/ui/add-content/__tests__/AddContentPage.test.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { configEnzymeAdapter } from 'testutils/helpers';
+import { shallow } from 'enzyme';
+import AddContentPage from 'ui/add-content/AddContentPage';
+
+configEnzymeAdapter();
+
+describe('AddContentPage', () => {
+  let component;
+  beforeEach(() => {
+    component = shallow(<AddContentPage />);
+  });
+  it('renders without crashing', () => {
+    expect(component.exists()).toEqual(true);
+  });
+});

--- a/src/ui/categories/common/CategoryTreeSelector.js
+++ b/src/ui/categories/common/CategoryTreeSelector.js
@@ -11,7 +11,7 @@ const CategoryTreeSelector = ({
   categories,
   onJoinCategory,
   onExpandCategory,
-  joinedCategories,
+  getJoinedCategoriesByCodes: joinedCategories,
   onUnjoinCategory,
 }) => {
   const contentCategoriesText = joinedCategories && joinedCategories.length > 0
@@ -40,6 +40,7 @@ const CategoryTreeSelector = ({
   const categoryRows = categories.map((category, i) => (
     <CategoryTreeSelectorRow
       category={category}
+      key={category.code}
       i={i}
       language={language}
       onExpandCategory={onExpandCategory}
@@ -83,7 +84,7 @@ CategoryTreeSelector.propTypes = {
 
   language: PropTypes.string.isRequired,
 
-  joinedCategories: PropTypes.arrayOf(PropTypes.shape({})),
+  getJoinedCategoriesByCodes: PropTypes.arrayOf(PropTypes.shape({})),
 
   input: PropTypes.shape({
     value: PropTypes.string.isRequired,
@@ -93,10 +94,10 @@ CategoryTreeSelector.propTypes = {
 
 CategoryTreeSelector.defaultProps = {
   categories: [],
+  getJoinedCategoriesByCodes: [],
   onExpandCategory: () => { },
   onJoinCategory: () => { },
   onUnjoinCategory: () => { },
-  joinedCategories: [],
 };
 
 export default CategoryTreeSelector;

--- a/src/ui/categories/common/CategoryTreeSelectorContainer.js
+++ b/src/ui/categories/common/CategoryTreeSelectorContainer.js
@@ -3,20 +3,19 @@ import CategoryTreeSelector from 'ui/categories/common/CategoryTreeSelector';
 
 import {
   handleExpandCategory,
-  handleJoinCategory,
   onUnjoinCategory,
+  onJoinCategory,
 } from 'state/categories/actions';
-import { getCategoryTree } from 'state/categories/selectors';
-import { getJoinedCategories } from 'state/edit-content/selectors';
+import { getCategoryTree, getJoinedCategoriesByCodes } from 'state/categories/selectors';
 
 export const mapStateToProps = state => ({
   categories: getCategoryTree(state),
-  joinedCategories: getJoinedCategories(state),
+  getJoinedCategoriesByCodes: getJoinedCategoriesByCodes(state),
 });
 
 export const mapDispatchToProps = dispatch => ({
   onExpandCategory: categoryCode => dispatch(handleExpandCategory(categoryCode)),
-  onJoinCategory: categoryCode => dispatch(handleJoinCategory(categoryCode)),
+  onJoinCategory: categoryCode => dispatch(onJoinCategory(categoryCode)),
   onUnjoinCategory: categoryCode => dispatch(onUnjoinCategory(categoryCode)),
 });
 

--- a/src/ui/categories/common/CategoryTreeSelectorRow.js
+++ b/src/ui/categories/common/CategoryTreeSelectorRow.js
@@ -38,7 +38,6 @@ const CategoryTreeSelectorRow = ({
       onKeyDown={() => onJoinCategory(category.code)}
     />
   ) : null;
-
   return (
     <tr key={category.code} className="CategoryTreeSelector__row">
       <td className={className.join(' ').trim()}>

--- a/src/ui/edit-content/EditContentFormContainer.js
+++ b/src/ui/edit-content/EditContentFormContainer.js
@@ -19,24 +19,26 @@ import {
   getWorkMode,
   getGroups,
   getLanguage,
+  getJoinedCategories,
 } from 'state/edit-content/selectors';
 import { WORK_MODE_EDIT } from 'state/edit-content/types';
 
-export const mapStateToProps = state => ({
+export const mapStateToProps = (state, { match: { params } }) => ({
   workMode: getWorkMode(state),
   language: getLanguage(state),
   content: getContent(state),
   groups: getGroups(state),
   currentUser: getCurrentUser(state),
+  contentId: params.id,
   ownerGroupDisabled: getOwnerGroupDisabled(state),
   selectedJoinGroups: formValueSelector('editcontentform')(state, 'joinGroups'),
-  selectedCategories: formValueSelector('editcontentform')(state, 'contentCategory'),
+  selectedCategories: getJoinedCategories(state),
 });
 
 export const mapDispatchToProps = dispatch => ({
   onDidMount: () => {
     dispatch(setWorkMode(WORK_MODE_EDIT));
-    dispatch(fetchContent());
+    dispatch(fetchContent('?status=published'));
     dispatch(fetchGroups());
     dispatch(fetchCategoryTree());
   },


### PR DESCRIPTION
Change logic of handling the categories provided by single content. That's why the tests are now updated and new tests are added. Fetching a single content is still an issue, because of that whole content list is fetched and one of them is chosen for editing.