### PR TITLE
EN6-115 change the reducers base location in the state to apps/cms/*

### DIFF
--- a/src/state/__tests__/categories/actions.test.js
+++ b/src/state/__tests__/categories/actions.test.js
@@ -32,13 +32,17 @@ const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 
 const INITIAL_STATE = {
-  categories: {
-    list: [],
-    map: {},
-    childrenMap: {},
-    titlesMap: {},
-    statusMap: {},
-    selected: null,
+  apps: {
+    cms: {
+      categories: {
+        list: [],
+        map: {},
+        childrenMap: {},
+        titlesMap: {},
+        statusMap: {},
+        selected: null,
+      },
+    },
   },
 };
 
@@ -112,7 +116,11 @@ describe('state/categories/actions', () => {
 
     it('when loading root category, should download the root and its children', (done) => {
       store = mockStore({
-        categories: { statusMap: { home: { expandend: false, loaded: false } } },
+        apps: {
+          cms: {
+            categories: { statusMap: { home: { expandend: false, loaded: false } } },
+          },
+        },
       });
       store
         .dispatch(handleExpandCategory('home'))

--- a/src/state/__tests__/categories/selectors.test.js
+++ b/src/state/__tests__/categories/selectors.test.js
@@ -27,150 +27,162 @@ const LOCALE_MOCK = 'en';
 jest.mock('state/locale/selectors', () => ({ getLocale: () => 'en' }));
 
 const MOCK_STATE = {
-  categories: {
-    list: ['home', 'mycategory1', 'mycategory2', 'mycategory3'],
-    map: {
-      home: HOME_PAYLOAD,
-      mycategory1: MYCATEGORY1_PAYLOAD,
-      mycategory2: MYCATEGORY2_PAYLOAD,
-      mycategory3: MYCATEGORY3_PAYLOAD,
-    },
-    childrenMap: {
-      home: HOME_PAYLOAD.children,
-      mycategory1: MYCATEGORY1_PAYLOAD.children,
-      mycategory2: MYCATEGORY2_PAYLOAD.children,
-      mycategory3: MYCATEGORY3_PAYLOAD.children,
-    },
-    titlesMap: {
-      home: HOME_PAYLOAD.titles,
-      mycategory1: MYCATEGORY1_PAYLOAD.titles,
-      mycategory2: MYCATEGORY2_PAYLOAD.titles,
-      mycategory3: MYCATEGORY3_PAYLOAD.titles,
-    },
-    statusMap: {
-      home: { expanded: true, loading: false, loaded: true },
-      mycategory1: {},
-      mycategory2: {},
-      mycategory3: {},
-    },
-    selected: {
-      ...MYCATEGORY1_PAYLOAD,
-      references: {
-        jpcollaborationIdeaManager: false,
-        DataObjectManager: false,
-        jacmsResourceManager: false,
-        jacmsContentManager: false,
-      },
-      referenceKeyList: [
-        'jpcollaborationIdeaManager',
-        'DataObjectManager',
-        'jacmsResourceManager',
-        'jacmsContentManager',
-      ],
-      referenceMap: {
-        jpcollaborationIdeaManager: [],
-        DataObjectManager: DATA_OBJECT_REFERENCES,
-        jacmsResourceManager: RESOURCE_REFERENCES,
-        jacmsContentManager: CONTENT_REFERENCES,
+  apps: {
+    cms: {
+      categories: {
+        list: ['home', 'mycategory1', 'mycategory2', 'mycategory3'],
+        map: {
+          home: HOME_PAYLOAD,
+          mycategory1: MYCATEGORY1_PAYLOAD,
+          mycategory2: MYCATEGORY2_PAYLOAD,
+          mycategory3: MYCATEGORY3_PAYLOAD,
+        },
+        childrenMap: {
+          home: HOME_PAYLOAD.children,
+          mycategory1: MYCATEGORY1_PAYLOAD.children,
+          mycategory2: MYCATEGORY2_PAYLOAD.children,
+          mycategory3: MYCATEGORY3_PAYLOAD.children,
+        },
+        titlesMap: {
+          home: HOME_PAYLOAD.titles,
+          mycategory1: MYCATEGORY1_PAYLOAD.titles,
+          mycategory2: MYCATEGORY2_PAYLOAD.titles,
+          mycategory3: MYCATEGORY3_PAYLOAD.titles,
+        },
+        statusMap: {
+          home: { expanded: true, loading: false, loaded: true },
+          mycategory1: {},
+          mycategory2: {},
+          mycategory3: {},
+        },
+        selected: {
+          ...MYCATEGORY1_PAYLOAD,
+          references: {
+            jpcollaborationIdeaManager: false,
+            DataObjectManager: false,
+            jacmsResourceManager: false,
+            jacmsContentManager: false,
+          },
+          referenceKeyList: [
+            'jpcollaborationIdeaManager',
+            'DataObjectManager',
+            'jacmsResourceManager',
+            'jacmsContentManager',
+          ],
+          referenceMap: {
+            jpcollaborationIdeaManager: [],
+            DataObjectManager: DATA_OBJECT_REFERENCES,
+            jacmsResourceManager: RESOURCE_REFERENCES,
+            jacmsContentManager: CONTENT_REFERENCES,
+          },
+        },
       },
     },
   },
 };
 
 const MOCK_STATE_2 = {
-  categories: {
-    list: ['home', 'mycategory1', 'mycategory2', 'mycategory3'],
-    map: {
-      home: HOME_PAYLOAD,
-      mycategory1: MYCATEGORY1_PAYLOAD,
-      mycategory2: MYCATEGORY2_PAYLOAD,
-      mycategory3: MYCATEGORY3_PAYLOAD,
-    },
-    childrenMap: {
-      home: HOME_PAYLOAD.children,
-      mycategory1: MYCATEGORY1_PAYLOAD.children,
-      mycategory2: MYCATEGORY2_PAYLOAD.children,
-      mycategory3: MYCATEGORY3_PAYLOAD.children,
-    },
-    titlesMap: {
-      home: HOME_PAYLOAD.titles,
-      mycategory1: MYCATEGORY1_PAYLOAD.titles,
-      mycategory2: MYCATEGORY2_PAYLOAD.titles,
-      mycategory3: MYCATEGORY3_PAYLOAD.titles,
-    },
-    statusMap: {
-      home: { expanded: false, loading: false, loaded: true },
-      mycategory1: {},
-      mycategory2: {},
-      mycategory3: {},
-    },
-    selected: {
-      ...MYCATEGORY1_PAYLOAD,
-      references: {
-        jpcollaborationIdeaManager: false,
-        DataObjectManager: false,
-        jacmsResourceManager: false,
-        jacmsContentManager: false,
-      },
-      referenceKeyList: [
-        'jpcollaborationIdeaManager',
-        'DataObjectManager',
-        'jacmsResourceManager',
-        'jacmsContentManager',
-      ],
-      referenceMap: {
-        jpcollaborationIdeaManager: [],
-        DataObjectManager: DATA_OBJECT_REFERENCES,
-        jacmsResourceManager: RESOURCE_REFERENCES,
-        jacmsContentManager: CONTENT_REFERENCES,
+  apps: {
+    cms: {
+      categories: {
+        list: ['home', 'mycategory1', 'mycategory2', 'mycategory3'],
+        map: {
+          home: HOME_PAYLOAD,
+          mycategory1: MYCATEGORY1_PAYLOAD,
+          mycategory2: MYCATEGORY2_PAYLOAD,
+          mycategory3: MYCATEGORY3_PAYLOAD,
+        },
+        childrenMap: {
+          home: HOME_PAYLOAD.children,
+          mycategory1: MYCATEGORY1_PAYLOAD.children,
+          mycategory2: MYCATEGORY2_PAYLOAD.children,
+          mycategory3: MYCATEGORY3_PAYLOAD.children,
+        },
+        titlesMap: {
+          home: HOME_PAYLOAD.titles,
+          mycategory1: MYCATEGORY1_PAYLOAD.titles,
+          mycategory2: MYCATEGORY2_PAYLOAD.titles,
+          mycategory3: MYCATEGORY3_PAYLOAD.titles,
+        },
+        statusMap: {
+          home: { expanded: false, loading: false, loaded: true },
+          mycategory1: {},
+          mycategory2: {},
+          mycategory3: {},
+        },
+        selected: {
+          ...MYCATEGORY1_PAYLOAD,
+          references: {
+            jpcollaborationIdeaManager: false,
+            DataObjectManager: false,
+            jacmsResourceManager: false,
+            jacmsContentManager: false,
+          },
+          referenceKeyList: [
+            'jpcollaborationIdeaManager',
+            'DataObjectManager',
+            'jacmsResourceManager',
+            'jacmsContentManager',
+          ],
+          referenceMap: {
+            jpcollaborationIdeaManager: [],
+            DataObjectManager: DATA_OBJECT_REFERENCES,
+            jacmsResourceManager: RESOURCE_REFERENCES,
+            jacmsContentManager: CONTENT_REFERENCES,
+          },
+        },
       },
     },
   },
 };
 
 const MOCK_STATE_3 = {
-  categories: {
-    list: ['home', 'mycategory1', 'mycategory3'],
-    map: {
-      home: HOME_PAYLOAD,
-      mycategory1: MYCATEGORY1_PAYLOAD,
-      mycategory3: MYCATEGORY3_PAYLOAD,
-    },
-    childrenMap: {
-      home: HOME_PAYLOAD.children,
-      mycategory1: MYCATEGORY1_PAYLOAD.children,
-      mycategory2: MYCATEGORY2_PAYLOAD.children,
-      mycategory3: MYCATEGORY3_PAYLOAD.children,
-    },
-    titlesMap: {
-      home: HOME_PAYLOAD.titles,
-      mycategory1: MYCATEGORY1_PAYLOAD.titles,
-      mycategory3: MYCATEGORY3_PAYLOAD.titles,
-    },
-    statusMap: {
-      home: { expanded: true, loading: false, loaded: true },
-      mycategory1: {},
-      mycategory3: {},
-    },
-    selected: {
-      ...MYCATEGORY1_PAYLOAD,
-      references: {
-        jpcollaborationIdeaManager: false,
-        DataObjectManager: false,
-        jacmsResourceManager: false,
-        jacmsContentManager: false,
-      },
-      referenceKeyList: [
-        'jpcollaborationIdeaManager',
-        'DataObjectManager',
-        'jacmsResourceManager',
-        'jacmsContentManager',
-      ],
-      referenceMap: {
-        jpcollaborationIdeaManager: [],
-        DataObjectManager: DATA_OBJECT_REFERENCES,
-        jacmsResourceManager: RESOURCE_REFERENCES,
-        jacmsContentManager: CONTENT_REFERENCES,
+  apps: {
+    cms: {
+      categories: {
+        list: ['home', 'mycategory1', 'mycategory3'],
+        map: {
+          home: HOME_PAYLOAD,
+          mycategory1: MYCATEGORY1_PAYLOAD,
+          mycategory3: MYCATEGORY3_PAYLOAD,
+        },
+        childrenMap: {
+          home: HOME_PAYLOAD.children,
+          mycategory1: MYCATEGORY1_PAYLOAD.children,
+          mycategory2: MYCATEGORY2_PAYLOAD.children,
+          mycategory3: MYCATEGORY3_PAYLOAD.children,
+        },
+        titlesMap: {
+          home: HOME_PAYLOAD.titles,
+          mycategory1: MYCATEGORY1_PAYLOAD.titles,
+          mycategory3: MYCATEGORY3_PAYLOAD.titles,
+        },
+        statusMap: {
+          home: { expanded: true, loading: false, loaded: true },
+          mycategory1: {},
+          mycategory3: {},
+        },
+        selected: {
+          ...MYCATEGORY1_PAYLOAD,
+          references: {
+            jpcollaborationIdeaManager: false,
+            DataObjectManager: false,
+            jacmsResourceManager: false,
+            jacmsContentManager: false,
+          },
+          referenceKeyList: [
+            'jpcollaborationIdeaManager',
+            'DataObjectManager',
+            'jacmsResourceManager',
+            'jacmsContentManager',
+          ],
+          referenceMap: {
+            jpcollaborationIdeaManager: [],
+            DataObjectManager: DATA_OBJECT_REFERENCES,
+            jacmsResourceManager: RESOURCE_REFERENCES,
+            jacmsContentManager: CONTENT_REFERENCES,
+          },
+        },
       },
     },
   },
@@ -179,7 +191,7 @@ const MOCK_STATE_3 = {
 describe('state/categories/selectors', () => {
   it('getCategories(state) returns the categories object', () => {
     const selected = getCategories(MOCK_STATE);
-    expect(selected).toBe(MOCK_STATE.categories);
+    expect(selected).toBe(MOCK_STATE.apps.cms.categories);
   });
 
   it('verify getGroupsIdList selector', () => {
@@ -190,22 +202,22 @@ describe('state/categories/selectors', () => {
 
   it('getCategoriesMap(state) returns the categories map', () => {
     const selected = getCategoriesMap(MOCK_STATE);
-    expect(selected).toBe(MOCK_STATE.categories.map);
+    expect(selected).toBe(MOCK_STATE.apps.cms.categories.map);
   });
 
   it('getChildrenMap(state) returns the categories object', () => {
     const selected = getChildrenMap(MOCK_STATE);
-    expect(selected).toBe(MOCK_STATE.categories.childrenMap);
+    expect(selected).toBe(MOCK_STATE.apps.cms.categories.childrenMap);
   });
 
   it('getTitlesMap(state) returns the categories object', () => {
     const selected = getTitlesMap(MOCK_STATE);
-    expect(selected).toBe(MOCK_STATE.categories.titlesMap);
+    expect(selected).toBe(MOCK_STATE.apps.cms.categories.titlesMap);
   });
 
   it('getStatusMap(state) returns the categories object', () => {
     const selected = getStatusMap(MOCK_STATE);
-    expect(selected).toBe(MOCK_STATE.categories.statusMap);
+    expect(selected).toBe(MOCK_STATE.apps.cms.categories.statusMap);
   });
 
   describe('getPageTreePages(state)', () => {
@@ -293,18 +305,18 @@ describe('state/categories/selectors', () => {
   describe('selected category', () => {
     it('getSelected(state)', () => {
       const selected = getSelected(MOCK_STATE);
-      expect(selected).toBe(MOCK_STATE.categories.selected);
+      expect(selected).toBe(MOCK_STATE.apps.cms.categories.selected);
     });
 
     it('getSelectedRefs(state)', () => {
       const selected = getSelectedRefs(MOCK_STATE);
-      expect(selected).toBe(MOCK_STATE.categories.selected.references);
+      expect(selected).toBe(MOCK_STATE.apps.cms.categories.selected.references);
     });
 
     it('getReferenceKeyList(state)', () => {
       const selected = getReferenceKeyList(MOCK_STATE);
       expect(selected).toHaveLength(4);
-      expect(selected).toBe(MOCK_STATE.categories.selected.referenceKeyList);
+      expect(selected).toBe(MOCK_STATE.apps.cms.categories.selected.referenceKeyList);
     });
 
     it('getReferenceMap(state)', () => {
@@ -313,7 +325,7 @@ describe('state/categories/selectors', () => {
       expect(selected).toHaveProperty('DataObjectManager');
       expect(selected).toHaveProperty('jacmsResourceManager');
       expect(selected).toHaveProperty('jacmsContentManager');
-      expect(selected).toBe(MOCK_STATE.categories.selected.referenceMap);
+      expect(selected).toBe(MOCK_STATE.apps.cms.categories.selected.referenceMap);
     });
   });
 });

--- a/src/state/__tests__/rootReducer.test.js
+++ b/src/state/__tests__/rootReducer.test.js
@@ -5,7 +5,11 @@ const state = reducer();
 describe('root reducer store', () => {
   it('contains the correct number of states', () => {
     expect(state).toBeInstanceOf(Object);
-    expect(Object.keys(state)).toHaveLength(11);
+    expect(Object.keys(state)).toHaveLength(8);
+  });
+  it('contains the apps & cms state', () => {
+    expect(state).toHaveProperty('apps');
+    expect(state.apps).toHaveProperty('cms');
   });
 
   it('contains the redux form state', () => {
@@ -17,10 +21,10 @@ describe('root reducer store', () => {
   });
 
   it('contains the editForm state', () => {
-    expect(state).toHaveProperty('editContent');
+    expect(state.apps.cms).toHaveProperty('editContent');
   });
 
   it('contains the categories state', () => {
-    expect(state).toHaveProperty('categories');
+    expect(state.apps.cms).toHaveProperty('categories');
   });
 });

--- a/src/state/categories/selectors.js
+++ b/src/state/categories/selectors.js
@@ -2,16 +2,16 @@ import { createSelector } from 'reselect';
 import { get } from 'lodash';
 import { getLocale } from 'state/locale/selectors';
 
-export const getCategories = state => state.categories;
-export const getCategoriesIdList = state => state.categories.list;
-export const getCategoriesMap = state => state.categories.map;
-export const getChildrenMap = state => state.categories.childrenMap;
-export const getStatusMap = state => state.categories.statusMap;
-export const getTitlesMap = state => state.categories.titlesMap;
-export const getSelected = state => get(state.categories, 'selected', {});
-export const getSelectedRefs = state => get(state.categories, 'selected.references', {});
-export const getReferenceKeyList = state => get(state.categories, 'selected.referenceKeyList', []);
-export const getReferenceMap = state => get(state.categories, 'selected.referenceMap', {});
+export const getCategories = state => state.apps.cms.categories;
+export const getCategoriesIdList = state => state.apps.cms.categories.list;
+export const getCategoriesMap = state => state.apps.cms.categories.map;
+export const getChildrenMap = state => state.apps.cms.categories.childrenMap;
+export const getStatusMap = state => state.apps.cms.categories.statusMap;
+export const getTitlesMap = state => state.apps.cms.categories.titlesMap;
+export const getSelected = state => get(state.apps.cms.categories, 'selected', {});
+export const getSelectedRefs = state => get(state.apps.cms.categories, 'selected.references', {});
+export const getReferenceKeyList = state => get(state.apps.cms.categories, 'selected.referenceKeyList', []);
+export const getReferenceMap = state => get(state.apps.cms.categories, 'selected.referenceMap', {});
 
 const CATEGORY_STATUS_DEFAULTS = {
   expanded: false,

--- a/src/state/content-model/__tests__/actions.test.js
+++ b/src/state/content-model/__tests__/actions.test.js
@@ -51,7 +51,7 @@ describe('contentModel thunks', () => {
   let store;
   beforeEach(() => {
     jest.unmock('api/contentModels');
-    store = createMockStore({ contentModel: { list: [], opened: {} } });
+    store = createMockStore({ apps: { cms: { contentModel: { list: [], opened: {} } } } });
   });
   it('fetchContentModelListPaged', (done) => {
     store.dispatch(fetchContentModelListPaged()).then(() => {

--- a/src/state/content-model/__tests__/selectors.test.js
+++ b/src/state/content-model/__tests__/selectors.test.js
@@ -3,7 +3,13 @@ import {
   getContentModelOpened,
 } from 'state/content-model/selectors';
 
-const TEST_STATE = { contentModel: { list: ['hello', 'world'], opened: { name: 'ciao', id: 1 } } };
+const TEST_STATE = {
+  apps: {
+    cms: {
+      contentModel: { list: ['hello', 'world'], opened: { name: 'ciao', id: 1 } },
+    },
+  },
+};
 
 it('verify getContentModelList selector', () => {
   const state = getContentModelList(TEST_STATE);

--- a/src/state/content-model/selectors.js
+++ b/src/state/content-model/selectors.js
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 
-export const getContentModelState = state => state.contentModel;
+export const getContentModelState = state => state.apps.cms.contentModel;
 
 export const getContentModelList = createSelector(
   getContentModelState,

--- a/src/state/content-type/__tests__/selectors.test.js
+++ b/src/state/content-type/__tests__/selectors.test.js
@@ -1,6 +1,6 @@
 import { getContentTypeList } from 'state/content-type/selectors';
 
-const TEST_STATE = { contentType: { list: ['hello', 'world'] } };
+const TEST_STATE = { apps: { cms: { contentType: { list: ['hello', 'world'] } } } };
 
 it('verify getContentTypeList selector', () => {
   const state = getContentTypeList(TEST_STATE);

--- a/src/state/content-type/selectors.js
+++ b/src/state/content-type/selectors.js
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 
-export const getContentTypeState = state => state.contentType;
+export const getContentTypeState = state => state.apps.cms.contentType;
 
 export const getContentTypeList = createSelector(
   getContentTypeState,

--- a/src/state/edit-content/__tests__/selectors.test.js
+++ b/src/state/edit-content/__tests__/selectors.test.js
@@ -1,6 +1,6 @@
 import { getJoinedCategories, getNewContentsType } from 'state/edit-content/selectors';
 
-const TEST_STATE = { editContent: { contentType: 'NEWS', joinedCategories: ['a', 'b'] } };
+const TEST_STATE = { apps: { cms: { editContent: { contentType: 'NEWS', joinedCategories: ['a', 'b'] } } } };
 
 it('verify getContentTypeList selector', () => {
   const newContentType = getNewContentsType(TEST_STATE);

--- a/src/state/edit-content/selectors.js
+++ b/src/state/edit-content/selectors.js
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 
-export const getEditContentState = state => state.editContent;
+export const getEditContentState = state => state.apps.cms.editContent;
 
 export const getOwnerGroupDisabled = createSelector(
   getEditContentState,

--- a/src/state/rootReducer.js
+++ b/src/state/rootReducer.js
@@ -11,16 +11,20 @@ import loading from 'state/loading/reducer';
 import modal from 'state/modal/reducer';
 import categories from 'state/categories/reducer';
 
-export default combineReducers({
-  api,
+const cms = combineReducers({
   contentModel,
   contentType,
-  currentUser,
   editContent,
+  categories,
+});
+
+export default combineReducers({
+  apps: combineReducers({ cms }),
+  api,
+  currentUser,
   form,
   loading,
   locale,
   messages,
   modal,
-  categories,
 });

--- a/src/testutils/mocks/categories.js
+++ b/src/testutils/mocks/categories.js
@@ -82,31 +82,35 @@ export const CATEGORY_TREE = {
 };
 
 export const STATE_NORMALIZED = {
-  categories: {
-    list: ['home', 'mycategory1', 'mycategory2', 'mycategory3'],
-    map: {
-      home: HOME_PAYLOAD,
-      mycategory1: MYCATEGORY1_PAYLOAD,
-      mycategory2: MYCATEGORY2_PAYLOAD,
-      mycategory3: MYCATEGORY3_PAYLOAD,
-    },
-    childrenMap: {
-      home: HOME_PAYLOAD.children,
-      mycategory1: MYCATEGORY1_PAYLOAD.children,
-      mycategory2: MYCATEGORY2_PAYLOAD.children,
-      mycategory3: MYCATEGORY3_PAYLOAD.children,
-    },
-    titlesMap: {
-      home: HOME_PAYLOAD.titles,
-      mycategory1: MYCATEGORY1_PAYLOAD.titles,
-      mycategory2: MYCATEGORY2_PAYLOAD.titles,
-      mycategory3: MYCATEGORY3_PAYLOAD.titles,
-    },
-    statusMap: {
-      home: { expanded: true, loading: false, loaded: true },
-      mycategory1: {},
-      mycategory2: {},
-      mycategory3: {},
+  apps: {
+    cms: {
+      categories: {
+        list: ['home', 'mycategory1', 'mycategory2', 'mycategory3'],
+        map: {
+          home: HOME_PAYLOAD,
+          mycategory1: MYCATEGORY1_PAYLOAD,
+          mycategory2: MYCATEGORY2_PAYLOAD,
+          mycategory3: MYCATEGORY3_PAYLOAD,
+        },
+        childrenMap: {
+          home: HOME_PAYLOAD.children,
+          mycategory1: MYCATEGORY1_PAYLOAD.children,
+          mycategory2: MYCATEGORY2_PAYLOAD.children,
+          mycategory3: MYCATEGORY3_PAYLOAD.children,
+        },
+        titlesMap: {
+          home: HOME_PAYLOAD.titles,
+          mycategory1: MYCATEGORY1_PAYLOAD.titles,
+          mycategory2: MYCATEGORY2_PAYLOAD.titles,
+          mycategory3: MYCATEGORY3_PAYLOAD.titles,
+        },
+        statusMap: {
+          home: { expanded: true, loading: false, loaded: true },
+          mycategory1: {},
+          mycategory2: {},
+          mycategory3: {},
+        },
+      },
     },
   },
   loading: { categories: false },

--- a/src/ui/__tests__/App.test.js
+++ b/src/ui/__tests__/App.test.js
@@ -19,22 +19,26 @@ const STATE = {
   loading: {},
   locale: 'en',
   messages: [],
-  contentModel: { list: [] },
   modal: { visibleModal: '', info: {} },
-  editContent: {
-    ownerGroupDisabled: {
-      disabled: false,
+  apps: {
+    cms: {
+      contentModel: { list: [] },
+      editContent: {
+        ownerGroupDisabled: {
+          disabled: false,
+        },
+        language: 'EN',
+        groups: [],
+        content: {},
+      },
+      categories: {
+        list: [],
+        map: [],
+        childrenMap: [],
+        statusMap: [],
+        titlesMap: [],
+      },
     },
-    language: 'EN',
-    groups: [],
-    content: {},
-  },
-  categories: {
-    list: [],
-    map: [],
-    childrenMap: [],
-    statusMap: [],
-    titlesMap: [],
   },
 };
 

--- a/src/ui/content-model/__tests__/AddContentModelFormContainer.test.js
+++ b/src/ui/content-model/__tests__/AddContentModelFormContainer.test.js
@@ -1,8 +1,12 @@
 import { mapStateToProps, mapDispatchToProps } from 'ui/content-model/AddContentModelFormContainer';
 
 const state = {
-  contentType: {
-    list: [],
+  apps: {
+    cms: {
+      contentType: {
+        list: [],
+      },
+    },
   },
 };
 

--- a/src/ui/content-model/__tests__/ContentModelListContainer.test.js
+++ b/src/ui/content-model/__tests__/ContentModelListContainer.test.js
@@ -1,8 +1,12 @@
 import { mapStateToProps, mapDispatchToProps } from 'ui/content-model/ContentModelListContainer';
 
 const state = {
-  contentModel: {
-    list: [],
+  apps: {
+    cms: {
+      contentModel: {
+        list: [],
+      },
+    },
   },
   loading: {},
 };

--- a/src/ui/content-model/__tests__/ContentModelListPage.test.js
+++ b/src/ui/content-model/__tests__/ContentModelListPage.test.js
@@ -15,7 +15,11 @@ configEnzymeAdapter();
 
 const initState = {
   loading: {},
-  contentModel: { list: [] },
+  apps: {
+    cms: {
+      contentModel: { list: [] },
+    },
+  },
   modal: { visibleModal: '', info: {} },
 };
 

--- a/src/ui/content-model/__tests__/EditContentModelFormContainer.test.js
+++ b/src/ui/content-model/__tests__/EditContentModelFormContainer.test.js
@@ -1,23 +1,27 @@
 import { mapStateToProps, mapDispatchToProps } from 'ui/content-model/EditContentModelFormContainer';
 
 const state = {
-  contentType: {
-    list: [
-      {
-        code: 'WEh',
-        name: 'yo',
+  apps: {
+    cms: {
+      contentType: {
+        list: [
+          {
+            code: 'WEh',
+            name: 'yo',
+          },
+          {
+            code: 'MOO',
+            name: 'to',
+          },
+        ],
       },
-      {
-        code: 'MOO',
-        name: 'to',
+      contentModel: {
+        opened: {
+          id: 1,
+          contentType: 'WEh',
+          descr: 'b',
+        },
       },
-    ],
-  },
-  contentModel: {
-    opened: {
-      id: 1,
-      contentType: 'WEh',
-      descr: 'b',
     },
   },
 };

--- a/src/ui/edit-content/__tests__/EditContentFormContainer.test.js
+++ b/src/ui/edit-content/__tests__/EditContentFormContainer.test.js
@@ -4,22 +4,26 @@ import { mapStateToProps, mapDispatchToProps } from 'ui/edit-content/EditContent
 import { EDIT_CONTENT_OPENED_OK } from 'testutils/mocks/editContent';
 
 const TEST_STATE = {
-  editContent: {
-    ownerGroupDisabled: {
-      disabled: false,
+  apps: {
+    cms: {
+      editContent: {
+        ownerGroupDisabled: {
+          disabled: false,
+        },
+        language: 'en',
+        workMode: 'work-mode-add',
+        content: {
+          contentType: 'NEWS',
+          version: '0.0',
+        },
+        groups: [
+          { code: 'adminstrators', name: 'Administrators' },
+          { code: 'freeAccess', name: 'Free Access' },
+        ],
+        selectedCategories: undefined,
+        selectedJoinGroups: undefined,
+      },
     },
-    language: 'en',
-    workMode: 'work-mode-add',
-    content: {
-      contentType: 'NEWS',
-      version: '0.0',
-    },
-    groups: [
-      { code: 'adminstrators', name: 'Administrators' },
-      { code: 'freeAccess', name: 'Free Access' },
-    ],
-    selectedCategories: undefined,
-    selectedJoinGroups: undefined,
   },
 };
 


### PR DESCRIPTION
Please let me know if the way I coded in `rootReducer.js` is correct or not. Only 4 related reducers have been modified, `categories`, `editContent`, `contentModel`, and `contentType`. Other branches will be modified same to this concept once this PR has been approved/merged.