### PR TITLE
EN6-92 Fix CMS menu height issue

### DIFF
--- a/src/sass/common/CMSShell.scss
+++ b/src/sass/common/CMSShell.scss
@@ -24,6 +24,14 @@
   }
 }
 
+.BrandMenu__first-level-menu {
+  &.nav.persistent-secondary {
+    .LinkMenuItem.active {
+      margin-bottom: 0;
+    }
+  }
+}
+
 .FirstLevelMenuItem {
   span .fa { // sass-lint:disable-line force-element-nesting class-name-format
     padding-right: 8px;


### PR DESCRIPTION
The fix is just by overriding the Patternfly style for active menu items in a persistent secondary navbar. It seems that they didn't consider a mix of multi-level menu items and single-level ones as the corresponding style appears to be only suitable for multi-level items.