### PR TITLE
ENG-125 change default form via div

### DIFF
--- a/src/ui/common/link-config/LinkConfigContentForm.js
+++ b/src/ui/common/link-config/LinkConfigContentForm.js
@@ -17,8 +17,8 @@ ContentsField.propTypes = {
   input: PropTypes.shape(fieldInputPropTypes).isRequired,
 };
 
-const LinkConfigContentForm = ({ onCancel, handleSubmit }) => (
-  <form className="form-horizontal" onSubmit={handleSubmit}>
+const LinkConfigContentForm = ({ onCancel, handleClick, selectedContent }) => (
+  <div className="form-horizontal">
     <Field
       component={ContentsField}
       name="content"
@@ -34,16 +34,21 @@ const LinkConfigContentForm = ({ onCancel, handleSubmit }) => (
       >
         <FormattedMessage id="cms.label.cancel" />
       </Button>
-      <Button bsStyle="primary" type="submit">
+      <Button bsStyle="primary" onClick={() => handleClick(selectedContent)}>
         <FormattedMessage id="cms.label.save" />
       </Button>
     </div>
-  </form>
+  </div>
 );
 
 LinkConfigContentForm.propTypes = {
   onCancel: PropTypes.func.isRequired,
-  handleSubmit: PropTypes.func.isRequired,
+  selectedContent: PropTypes.string,
+  handleClick: PropTypes.func.isRequired,
+};
+
+LinkConfigContentForm.defaultProps = {
+  selectedContent: '',
 };
 
 export default reduxForm({

--- a/src/ui/common/link-config/LinkConfigContentFormContainer.js
+++ b/src/ui/common/link-config/LinkConfigContentFormContainer.js
@@ -1,0 +1,25 @@
+import { connect } from 'react-redux';
+import { formValueSelector, submit } from 'redux-form';
+import LinkConfigContentForm from 'ui/common/link-config/LinkConfigContentForm';
+
+export const mapStateToProps = state => ({
+  selectedContent: formValueSelector('LinkConfigContent')(state, 'content'),
+});
+
+export const mapDispatchToProps = (state, { onSubmit }) => ({
+  handleClick: (content) => {
+    submit('LinkConfigContent');
+    onSubmit({ content });
+  },
+});
+
+const LinkConfigContentFormContainer = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+  null,
+  {
+    pure: false,
+  },
+)(LinkConfigContentForm);
+
+export default LinkConfigContentFormContainer;

--- a/src/ui/common/modal/LinkConfigModal.js
+++ b/src/ui/common/modal/LinkConfigModal.js
@@ -11,7 +11,7 @@ import { FormattedMessage } from 'react-intl';
 import GenericModal from 'ui/common/modal/GenericModal';
 import LinkConfigUrlForm from 'ui/common/link-config/LinkConfigUrlForm';
 import LinkConfigPageForm from 'ui/common/link-config/LinkConfigPageForm';
-import LinkConfigContentForm from 'ui/common/link-config/LinkConfigContentForm';
+import LinkConfigContentFormContainer from 'ui/common/link-config/LinkConfigContentFormContainer';
 import LinkConfigResourceForm from 'ui/common/link-config/LinkConfigResourceForm';
 
 const getLinkUrl = (type, value) => `#!${type};${value}!#`;
@@ -23,7 +23,6 @@ const LinkConfigModal = ({
 }) => {
   const handleSubmit = (values) => {
     const linkObj = { ...values.attributes };
-
     if (values.url) {
       linkObj.url = getLinkUrl('U', values.url);
     } else if (values.page) {
@@ -95,7 +94,7 @@ const LinkConfigModal = ({
           <LinkConfigPageForm onSubmit={handleSubmit} onCancel={onClose} />
         </Tab>
         <Tab eventKey="content" title={renderedContentTabTitle}>
-          <LinkConfigContentForm onSubmit={handleSubmit} onCancel={onClose} />
+          <LinkConfigContentFormContainer onSubmit={handleSubmit} onCancel={onClose} />
         </Tab>
         {hasResourceTab && (
           <Tab eventKey="resource" title={renderedResourceTabTitle}>


### PR DESCRIPTION
- Previous implementation used `form` for assigning a content. Unfortunately content list container paginator was also using `form`, so HTML error `form under form is not acceptable` was thrown in dev console. That's why I re-implemented with `div` instead of `form` and manually triggered `submit` via `mapDispatcToProps`.