### PR TITLE
ENG-369 Always convert BooleanAttributeField input value to string

### DIFF
--- a/src/ui/edit-content/content-attributes/BooleanAttributeField.js
+++ b/src/ui/edit-content/content-attributes/BooleanAttributeField.js
@@ -24,7 +24,7 @@ const BooleanAttributeField = ({
   const attrInput = {
     ...input,
     name,
-    value: inputValue || 'false',
+    value: `${inputValue || 'false'}`,
     onChange: (val) => {
       inputOnChange(val);
     },


### PR DESCRIPTION
Fixes boolean attribute not reflecting API response value when editing a content.