### PR TITLE
ENG-527: fixes default content model list field name

### DIFF
--- a/src/ui/content-type/AddContentTypeForm.js
+++ b/src/ui/content-type/AddContentTypeForm.js
@@ -144,7 +144,7 @@ export class AddContentTypeFormBody extends Component {
               label={
                 <FormLabel labelId="cms.contenttype.form.metadata.defaultContentTemplateLists" />
               }
-              name="defaultContentModelLists"
+              name="defaultContentModelList"
             />
           </div>
         );


### PR DESCRIPTION
Hi @gidesan @joewhite101 ,
this commit fixes a bug  on the Content types edit/add page , the "Default content template for lists" was always set to "No template".
Could you please have a look?

Thanks