### PR TITLE
ENG-519 implement cms side for expand/collapse all

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@entando/cms",
-  "version": "0.2.50",
+  "version": "0.2.51",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1248,9 +1248,9 @@
       }
     },
     "@entando/pagetreeselector": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@entando/pagetreeselector/-/pagetreeselector-1.1.0.tgz",
-      "integrity": "sha512-GHtOhPqSHa8Cavk6jEUiEVfbQP3yDNPu1XUpFSyqEEn2b1tPtHE+9mca3kbQ7H26WZx8maIMZAa5AGukD5KE4w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@entando/pagetreeselector/-/pagetreeselector-2.0.0.tgz",
+      "integrity": "sha512-RmU70highio+q8rPOdUl1T8E8vST5vYc2EGYd9qYadUV6RJjVx8/gCb0JqWB3RY2R+/hY/ryHSyzSOaRI3kk7A==",
       "requires": {
         "react": "^16.3.0",
         "react-dom": "^16.12.0",
@@ -1808,8 +1808,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-1.2.2.tgz",
       "integrity": "sha512-6pBxzJ8ZP3dYEQ4YjQ+NVbQaOflfgXq/JbDiS99oLobM2o72uAST4q6yPxHv6FOTCRC/n35ktuo8pvw/S4M7sw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@types/d3-dispatch": {
       "version": "1.0.7",
@@ -1832,8 +1831,7 @@
       "version": "1.0.36",
       "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-1.0.36.tgz",
       "integrity": "sha512-jbIWQ27QJcBNMZbQv0NSQMHnBDCmxghAxePxgyiPH1XPCRkOsTBei7jcdi3fDrUCGpCV3lKrSZFSlOkhUQVClA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@types/d3-ease": {
       "version": "1.0.9",
@@ -1878,7 +1876,6 @@
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-1.3.1.tgz",
       "integrity": "sha512-z8Zmi08XVwe8e62vP6wcA+CNuRhpuUU5XPEfqpG0hRypDE5BWNthQHB1UNWWDB7ojCbGaN4qBdsWp5kWxhT1IQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "@types/d3-color": "*"
       }
@@ -1887,8 +1884,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.8.tgz",
       "integrity": "sha512-AZGHWslq/oApTAHu9+yH/Bnk63y9oFOMROtqPAtxl5uB6qm1x2lueWdVEjsjjV3Qc2+QfuzKIwIR5MvVBakfzA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@types/d3-polygon": {
       "version": "1.0.7",
@@ -1942,8 +1938,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-1.4.1.tgz",
       "integrity": "sha512-bv8IfFYo/xG6dxri9OwDnK3yCagYPeRIjTlrcdYJSx+FDWlCeBDepIHUpqROmhPtZ53jyna0aUajZRk0I3rXNA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@types/d3-shape": {
       "version": "1.3.2",
@@ -1959,8 +1954,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.0.10.tgz",
       "integrity": "sha512-aKf62rRQafDQmSiv1NylKhIMmznsjRN+MnXRXTqHoqm0U/UZzVpdrtRnSIfdiLS616OuC1soYeX1dBg2n1u8Xw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@types/d3-time-format": {
       "version": "2.1.1",
@@ -5024,7 +5018,6 @@
       "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.10.20.tgz",
       "integrity": "sha512-4E4S7tTU607N3h0fZPkGmAtr9mwy462u+VJ6gxYZ8MxcRIjZqHy3Dv1GNry7i3zQCktTdWbULVKBbkAJkuHEnQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "jquery": ">=1.7"
       }
@@ -7061,8 +7054,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7083,14 +7075,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7105,20 +7095,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7235,8 +7222,7 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7248,7 +7234,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7263,7 +7248,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7271,14 +7255,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7297,7 +7279,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7387,8 +7368,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7400,7 +7380,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7486,8 +7465,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7523,7 +7501,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7543,7 +7520,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7587,14 +7563,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -10979,8 +10953,7 @@
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "moment-timezone": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@babel/runtime": "^7.9.2",
     "@entando/apimanager": "^6.2.1",
-    "@entando/pagetreeselector": "^1.1.0",
+    "@entando/pagetreeselector": "^2.0.0",
     "brace": "^0.11.1",
     "react-ace": "^7.0.2",
     "react-bootstrap-typeahead": "^3.4.6",

--- a/src/state/pages/__tests__/reducer.test.js
+++ b/src/state/pages/__tests__/reducer.test.js
@@ -7,7 +7,7 @@ import {
 
 import {
   addPages, togglePageExpanded, setPageLoading,
-  setPageLoaded, setViewPages, setSearchPages,
+  setPageLoaded, setViewPages, setSearchPages, clearTree, setBatchExpanded, collapseAll,
 } from 'state/pages/actions';
 
 const initialState = {
@@ -112,6 +112,48 @@ describe('state/pages/reducer', () => {
     expect(reducer(initialState, action)).toEqual({
       ...initialState,
       searchPages: payload,
+    });
+  });
+
+  describe('action CLEAR_TREE', () => {
+    let state;
+    beforeEach(() => {
+      state = reducer({}, addPages(PAGES));
+    });
+
+    let newState;
+    it('should clear the tree', () => {
+      newState = reducer(state, clearTree());
+      expect(newState.statusMap).toEqual({});
+    });
+  });
+
+  describe('action COLLAPSE_ALL', () => {
+    let state;
+    beforeEach(() => {
+      state = reducer({}, addPages(PAGES));
+    });
+
+    let newState;
+    it('should collapse all the tree', () => {
+      newState = reducer(state, togglePageExpanded('homepage'));
+      expect(newState.statusMap.homepage.expanded).toBe(true);
+      newState = reducer(newState, collapseAll());
+      Object.values(newState.statusMap).map(v => expect(v.expanded).toBe(false));
+    });
+  });
+
+  describe('action BATCH_TOGGLE_EXPANDED', () => {
+    let state;
+    beforeEach(() => {
+      state = reducer({}, addPages(PAGES));
+    });
+
+    let newState;
+    it('should collapse all the tree', () => {
+      newState = reducer(state, setBatchExpanded(['homepage', 'dashboard']));
+      expect(newState.statusMap.homepage.expanded).toBe(true);
+      expect(newState.statusMap.dashboard.expanded).toBe(true);
     });
   });
 });

--- a/src/state/pages/reducer.js
+++ b/src/state/pages/reducer.js
@@ -6,6 +6,9 @@ import {
   SET_PAGE_LOADED,
   SET_VIEWPAGES,
   SEARCH_PAGES,
+  CLEAR_TREE,
+  BATCH_TOGGLE_EXPANDED,
+  COLLAPSE_ALL,
 } from 'state/pages/types';
 
 // creates a map from an array
@@ -27,6 +30,9 @@ const reducer = (state = {}, action = {}) => {
         ...toMap(pages),
       };
     }
+    case CLEAR_TREE: {
+      return [];
+    }
     default: return state;
   }
 };
@@ -47,6 +53,9 @@ const childrenMap = (state = {}, action = {}) => {
         ...newValues,
       };
     }
+    case CLEAR_TREE: {
+      return {};
+    }
     default: return state;
   }
 };
@@ -59,8 +68,20 @@ const titlesMap = (state = {}, action = {}) => {
         ...toMap(action.payload.pages, 'titles'),
       };
     }
+    case CLEAR_TREE: {
+      return {};
+    }
     default: return state;
   }
+};
+
+const toggleBatchExpandedValues = (arr, toggleValue) => {
+  const newState = {};
+  arr.map((pg) => {
+    newState[pg] = { loaded: true, loading: false, expanded: toggleValue };
+    return pg;
+  });
+  return newState;
 };
 
 const statusMap = (state = {}, action = {}) => {
@@ -87,6 +108,22 @@ const statusMap = (state = {}, action = {}) => {
         [pageCode]: { ...state[pageCode], loaded: true, loading: false },
       };
     }
+    case CLEAR_TREE: {
+      return {};
+    }
+    case BATCH_TOGGLE_EXPANDED: {
+      const pageCodes = action.payload;
+      return toggleBatchExpandedValues(pageCodes, true);
+    }
+    case COLLAPSE_ALL: {
+      const newState = {};
+      const pageCodes = Object.keys(state);
+      pageCodes.map((p) => {
+        newState[p] = { expanded: false, loading: false, loaded: state[p].loaded };
+        return p;
+      });
+      return newState;
+    }
     default: return state;
   }
 };
@@ -95,6 +132,9 @@ const viewPages = (state = [], { type, payload } = {}) => {
   switch (type) {
     case SET_VIEWPAGES:
       return payload;
+    case CLEAR_TREE: {
+      return [];
+    }
     default:
       return state;
   }

--- a/src/state/pages/types.js
+++ b/src/state/pages/types.js
@@ -4,3 +4,6 @@ export const ADD_PAGES = 'pages/add-pages';
 export const SET_PAGE_LOADING = 'pages/set-page-loading';
 export const SET_PAGE_LOADED = 'pages/set-page-loaded';
 export const TOGGLE_PAGE_EXPANDED = 'pages/toggle-page-expanded';
+export const CLEAR_TREE = 'pages/clear-tree';
+export const BATCH_TOGGLE_EXPANDED = 'pages/set-all-pages-expanded';
+export const COLLAPSE_ALL = 'pages/collapse-all-pages';

--- a/src/ui/common/page/PageTreeSelectContainer.js
+++ b/src/ui/common/page/PageTreeSelectContainer.js
@@ -1,16 +1,25 @@
 import { connect } from 'react-redux';
 
 import { PageTreeSelector } from '@entando/pagetreeselector';
-import { handleExpandPage } from 'state/pages/actions';
+import {
+  handleExpandPage, fetchPageTreeAll, collapseAll, clearTree,
+} from 'state/pages/actions';
 import { getPageTreePages } from 'state/pages/selectors';
+import { getLoading } from 'state/loading/selectors';
 
 export const mapStateToProps = state => ({
   pages: getPageTreePages(state),
+  loading: getLoading(state).pageTree,
 });
 
 export const mapDispatchToProps = dispatch => ({
-  onDidMount: () => dispatch(handleExpandPage()),
+  onDidMount: () => {
+    dispatch(clearTree());
+    dispatch(handleExpandPage());
+  },
   onExpandPage: pageCode => dispatch(handleExpandPage(pageCode)),
+  onExpandAll: () => dispatch(fetchPageTreeAll()),
+  onCollapseAll: () => dispatch(collapseAll()),
 });
 
 


### PR DESCRIPTION
This PR is marked as draft because once `frontend-libraries` has a newer version of `pagetreeselector` its version also needs to be bumped up in`entando-cms`.