### PR TITLE
ENG-466 asset filename retrieval basis refactored

### DIFF
--- a/src/state/assets/__tests__/selectors.test.js
+++ b/src/state/assets/__tests__/selectors.test.js
@@ -76,7 +76,7 @@ it('verify condense function', () => {
   expect(res.versions[0].dimensions).toEqual(dimension);
   expect(res.metadata.dimension).toEqual(dimension);
   expect(res.versions[0].sizetype).toEqual('orig');
-  expect(res.metadata.filename).toEqual('a-ping-d0.png');
+  expect(res.metadata.filename).toEqual('temp_a-ping-d0.png');
 });
 
 

--- a/src/state/assets/selectors.js
+++ b/src/state/assets/selectors.js
@@ -47,7 +47,7 @@ export const condenseAssetInfo = (asset, domain) => {
   const origpath = versions[0].path;
   const newVersions = isImg ? refineImageVersions(versions, domain, dimension) : {};
   const filestrparts = origpath.split('/');
-  const filename = filestrparts[filestrparts.length - 1];
+  const filename = get(metadata, 'File Name', filestrparts[filestrparts.length - 1]);
   const newMetadata = {
     ...metadata,
     type: metadata['Detected File Type Name'],


### PR DESCRIPTION
on edit asset cropping - error occurs when saving protected asset because structure of filename has been modified (on `versions` key), so this needs to be using the name in "File Name" of  asset's metadata map