### PR TITLE
ENG-542 CMS widget list of contents filter value not showing

### DIFF
--- a/src/ui/common/form/FiltersSelectRenderer.js
+++ b/src/ui/common/form/FiltersSelectRenderer.js
@@ -19,14 +19,14 @@ class FiltersSelectRenderer extends Component {
   render() {
     const {
       fields, filterName,
-      options, suboptions, onResetFilterOption,
+      options, suboptions, onChangeFilterValue,
     } = this.props;
 
     const handleAddNewFilter = () => fields.push();
 
     const renderFilters = fields.map((filter, i) => {
       const filterField = fields.get(i) || {};
-      const { code } = filterField;
+      const { key } = filterField;
       return (
         // eslint-disable-next-line react/no-array-index-key
         <tr key={i}>
@@ -42,24 +42,26 @@ class FiltersSelectRenderer extends Component {
           </td>
           <td>
             <Field
-              name={`${filter}.code`}
+              name={`${filter}.key`}
               component="select"
               className="form-control"
-              onChange={() => onResetFilterOption(filterName, i)}
+              onChange={({ currentTarget }) => (
+                onChangeFilterValue(filterName, i, currentTarget.value)
+              )}
             >
               {this.filterOptions(options)}
             </Field>
           </td>
           <td>
             {
-              code && suboptions[code] && suboptions[code].length > 0
+              key && suboptions[key] && suboptions[key].length > 0
               && (
               <Field
                 name={filterName === 'filter' ? `${filter}.order` : `${filter}.categoryCode`}
                 component="select"
                 className="form-control"
               >
-                {this.filterOptions(suboptions[code])}
+                {this.filterOptions(suboptions[key])}
               </Field>
               )
             }
@@ -145,7 +147,7 @@ FiltersSelectRenderer.propTypes = {
   }).isRequired,
   options: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   suboptions: PropTypes.shape({}),
-  onResetFilterOption: PropTypes.func.isRequired,
+  onChangeFilterValue: PropTypes.func.isRequired,
   filterName: PropTypes.string.isRequired,
 };
 

--- a/src/ui/widget-forms/ContentsQueryConfig.js
+++ b/src/ui/widget-forms/ContentsQueryConfig.js
@@ -68,7 +68,7 @@ export class ContentsQueryFormBody extends Component {
     const {
       contentTypes, contentTemplates, categories, pages,
       onResetModelId, selectedContentType, selectedCategories,
-      intl, onResetFilterOption, languages, onToggleInclusiveOr,
+      intl, onChangeFilterValue, languages, onToggleInclusiveOr,
       selectedInclusiveOr, handleSubmit, invalid, submitting,
       dirty, onCancel, onDiscard, onSave,
     } = this.props;
@@ -329,7 +329,7 @@ export class ContentsQueryFormBody extends Component {
                           name="filters"
                           options={filters}
                           suboptions={filtersSuboptions}
-                          onResetFilterOption={onResetFilterOption}
+                          onChangeFilterValue={onChangeFilterValue}
                           filterName="filters"
                         />
                       </Col>
@@ -391,7 +391,7 @@ export class ContentsQueryFormBody extends Component {
                           name="userFilters"
                           options={frontendFilters}
                           suboptions={frontendFiltersSuboptions}
-                          onResetFilterOption={onResetFilterOption}
+                          onChangeFilterValue={onChangeFilterValue}
                           filterName="frontendFilters"
                         />
                       </Col>
@@ -440,7 +440,7 @@ ContentsQueryFormBody.propTypes = {
   pages: PropTypes.arrayOf(PropTypes.shape({})),
   categories: PropTypes.arrayOf(PropTypes.shape({})),
   selectedCategories: PropTypes.arrayOf(PropTypes.string),
-  onResetFilterOption: PropTypes.func.isRequired,
+  onChangeFilterValue: PropTypes.func.isRequired,
   onChangeContentType: PropTypes.func.isRequired,
   onToggleInclusiveOr: PropTypes.func.isRequired,
   onResetModelId: PropTypes.func.isRequired,

--- a/src/ui/widget-forms/ContentsQueryConfigContainer.js
+++ b/src/ui/widget-forms/ContentsQueryConfigContainer.js
@@ -68,7 +68,10 @@ export const mapDispatchToProps = (dispatch, ownProps) => ({
       }
     });
   },
-  onResetFilterOption: (name, i) => dispatch(change(ContentsQueryContainerId, `${name}.[${i}].option`, '')),
+  onChangeFilterValue: (name, i, value) => {
+    dispatch(change(ContentsQueryContainerId, `${name}.[${i}].code`, value));
+    dispatch(change(ContentsQueryContainerId, `${name}.[${i}].option`, ''));
+  },
   onChangeContentType: (contentType) => {
     if (contentType) dispatch(fetchContentTemplatesByContentType(contentType));
   },


### PR DESCRIPTION
`key` prop of a `filter` is being used on adminconsole's CMS widget setting but on app-builder - it's using `code` instead of `key`. so I used the `key` as the actual form field in app-builder (instead of `code`) but when its field change event is invoked, it will set the `code` field same as `key` field.