### PR TITLE
ENG-659 - frontend filter choices for CMS widget

### DIFF
--- a/src/ui/common/form/FiltersSelectRenderer.js
+++ b/src/ui/common/form/FiltersSelectRenderer.js
@@ -18,11 +18,18 @@ class FiltersSelectRenderer extends Component {
 
   render() {
     const {
-      fields, filterName,
+      fields, filterName, attributeFilterChoices,
       options, suboptions, onChangeFilterValue,
+      onResetFilterOption,
     } = this.props;
 
     const handleAddNewFilter = () => fields.push();
+
+    const handleFilterChange = (value, index) => {
+      onResetFilterOption(filterName, index);
+      const attributeFilter = attributeFilterChoices.findIndex(({ code }) => code === value) > -1;
+      onChangeFilterValue(fields.name, index, attributeFilter);
+    };
 
     const renderFilters = fields.map((filter, i) => {
       const filterField = fields.get(i) || {};
@@ -45,9 +52,7 @@ class FiltersSelectRenderer extends Component {
               name={`${filter}.key`}
               component="select"
               className="form-control"
-              onChange={({ currentTarget }) => (
-                onChangeFilterValue(filterName, i, currentTarget.value)
-              )}
+              onChange={({ currentTarget }) => handleFilterChange(currentTarget.value, i)}
             >
               {this.filterOptions(options)}
             </Field>
@@ -138,6 +143,7 @@ class FiltersSelectRenderer extends Component {
 FiltersSelectRenderer.propTypes = {
   intl: intlShape.isRequired,
   fields: PropTypes.shape({
+    name: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
     push: PropTypes.func,
     map: PropTypes.func,
     get: PropTypes.func,
@@ -148,7 +154,9 @@ FiltersSelectRenderer.propTypes = {
   options: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   suboptions: PropTypes.shape({}),
   onChangeFilterValue: PropTypes.func.isRequired,
+  onResetFilterOption: PropTypes.func.isRequired,
   filterName: PropTypes.string.isRequired,
+  attributeFilterChoices: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
 };
 
 FiltersSelectRenderer.defaultProps = {

--- a/src/ui/widget-forms/ContentsQueryConfig.js
+++ b/src/ui/widget-forms/ContentsQueryConfig.js
@@ -66,11 +66,11 @@ export class ContentsQueryFormBody extends Component {
 
   render() {
     const {
-      contentTypes, contentTemplates, categories, pages,
+      contentTypes, contentType, contentTemplates, categories, pages,
       onResetModelId, selectedContentType, selectedCategories,
-      intl, onChangeFilterValue, languages, onToggleInclusiveOr,
-      selectedInclusiveOr, handleSubmit, invalid, submitting,
-      dirty, onCancel, onDiscard, onSave,
+      intl, onChangeFilterValue, onResetFilterOption, languages,
+      onToggleInclusiveOr, selectedInclusiveOr, handleSubmit, invalid,
+      submitting, dirty, onCancel, onDiscard, onSave,
     } = this.props;
     const {
       publishingSettings, filters: filtersPanel,
@@ -114,6 +114,17 @@ export class ContentsQueryFormBody extends Component {
     const inclusiveOrOptions = [{ id: 'true', label: intl.formatMessage({ id: 'widget.form.inclusiveOr' }) }];
 
     const renderCategories = selectedCategories;
+
+    const getListAttributeFilters = () => {
+      if (!contentType.attributes) {
+        return [];
+      }
+      const attributeFilters = contentType.attributes.filter(attribute => attribute.listFilter);
+      return attributeFilters.map(({ code }) => ({
+        code,
+        name: `Attribute: ${code}`,
+      }));
+    };
 
     const ButtonComponent = () => (
       <Button
@@ -171,10 +182,13 @@ export class ContentsQueryFormBody extends Component {
       modified: orderFilters,
     };
 
+    const attributeFilters = getListAttributeFilters();
+
     const frontendFilters = [
       { code: '', nameId: 'widget.form.selectFilter' },
       { code: 'fulltext', nameId: 'widget.form.text' },
       { code: 'category', nameId: 'menu.categories' },
+      ...attributeFilters,
     ];
 
     const allCategories = [{
@@ -186,6 +200,7 @@ export class ContentsQueryFormBody extends Component {
     const frontendFiltersSuboptions = {
       fulltext: [],
       category: allCategories,
+      ...attributeFilters.map(({ code }) => ({ [code]: [] })),
     };
 
     const handleContentTypeChange = () => onResetModelId();
@@ -329,8 +344,10 @@ export class ContentsQueryFormBody extends Component {
                           name="filters"
                           options={filters}
                           suboptions={filtersSuboptions}
+                          onResetFilterOption={onResetFilterOption}
                           onChangeFilterValue={onChangeFilterValue}
                           filterName="filters"
+                          attributeFilterChoices={attributeFilters}
                         />
                       </Col>
                     </FormGroup>
@@ -391,8 +408,10 @@ export class ContentsQueryFormBody extends Component {
                           name="userFilters"
                           options={frontendFilters}
                           suboptions={frontendFiltersSuboptions}
+                          onResetFilterOption={onResetFilterOption}
                           onChangeFilterValue={onChangeFilterValue}
                           filterName="frontendFilters"
+                          attributeFilterChoices={attributeFilters}
                         />
                       </Col>
                     </FormGroup>
@@ -436,10 +455,14 @@ ContentsQueryFormBody.propTypes = {
   invalid: PropTypes.bool,
   submitting: PropTypes.bool,
   contentTypes: PropTypes.arrayOf(PropTypes.shape({})),
+  contentType: PropTypes.shape({
+    attributes: PropTypes.arrayOf(PropTypes.shape({})),
+  }),
   contentTemplates: PropTypes.arrayOf(PropTypes.shape({})),
   pages: PropTypes.arrayOf(PropTypes.shape({})),
   categories: PropTypes.arrayOf(PropTypes.shape({})),
   selectedCategories: PropTypes.arrayOf(PropTypes.string),
+  onResetFilterOption: PropTypes.func.isRequired,
   onChangeFilterValue: PropTypes.func.isRequired,
   onChangeContentType: PropTypes.func.isRequired,
   onToggleInclusiveOr: PropTypes.func.isRequired,
@@ -457,6 +480,7 @@ ContentsQueryFormBody.defaultProps = {
   submitting: false,
   languages: [],
   contentTypes: [],
+  contentType: {},
   contentTemplates: [],
   categories: [],
   pages: [],

--- a/src/ui/widget-forms/ContentsQueryConfigContainer.js
+++ b/src/ui/widget-forms/ContentsQueryConfigContainer.js
@@ -9,10 +9,10 @@ import { sendPutWidgetConfig } from 'state/page-config/actions';
 import { fetchSearchPages } from 'state/pages/actions';
 import { fetchLanguages } from 'state/languages/actions';
 import { fetchCategoryTree } from 'state/categories/actions';
-import { fetchContentTypeListPaged } from 'state/content-type/actions';
+import { fetchContentTypeListPaged, fetchContentType } from 'state/content-type/actions';
 import { fetchContentTemplatesByContentType } from 'state/content-template/actions';
 
-import { getContentTypeList } from 'state/content-type/selectors';
+import { getContentTypeList, getSelectedContentType } from 'state/content-type/selectors';
 import { getCategoryTree } from 'state/categories/selectors';
 import ContentsQueryConfig from 'ui/widget-forms/ContentsQueryConfig';
 import { getContentTemplateList } from 'state/content-template/selectors';
@@ -32,6 +32,7 @@ export const mapStateToProps = (state, ownProps) => ({
   language: getLocale(state),
   languages: getActiveLanguages(state),
   contentTypes: getContentTypeList(state),
+  contentType: getSelectedContentType(state),
   pages: getSearchPagesRaw(state),
   categories: getCategoryTree(state),
   contentTemplates: getContentTemplateList(state),
@@ -68,12 +69,15 @@ export const mapDispatchToProps = (dispatch, ownProps) => ({
       }
     });
   },
+  onResetFilterOption: (name, i) => dispatch(change(ContentsQueryContainerId, `${name}.[${i}].option`, '')),
   onChangeFilterValue: (name, i, value) => {
-    dispatch(change(ContentsQueryContainerId, `${name}.[${i}].code`, value));
-    dispatch(change(ContentsQueryContainerId, `${name}.[${i}].option`, ''));
+    dispatch(change(ContentsQueryContainerId, `${name}.[${i}].attributeFilter`, value));
   },
   onChangeContentType: (contentType) => {
-    if (contentType) dispatch(fetchContentTemplatesByContentType(contentType));
+    if (contentType) {
+      dispatch(fetchContentTemplatesByContentType(contentType));
+      dispatch(fetchContentType(contentType));
+    }
   },
   onResetModelId: () => dispatch(change(ContentsQueryContainerId, 'modelId', '')),
   onToggleInclusiveOr: value => dispatch(change(ContentsQueryContainerId, 'orClauseCategoryFilter', value === 'true' ? '' : 'true')),


### PR DESCRIPTION
frontend filter choices are now added with selected content type attributes that are marked for list filters (`listFilter`). Also restored the resetFilterOption function on widget config