### PR TITLE
ENG-716 table columns

### DIFF
--- a/src/babel.js
+++ b/src/babel.js
@@ -23,6 +23,9 @@ const cms = {
     row_content_viewer_list: MultipleContentsConfigContainer,
     search_result: null,
   },
+  persistData: {
+    tableColumns: ['currentColumnsShow'],
+  },
 };
 
 export default cms;

--- a/src/state/__tests__/rootReducer.test.js
+++ b/src/state/__tests__/rootReducer.test.js
@@ -11,7 +11,7 @@ describe('root reducer store', () => {
   it('contains the apps & cms state', () => {
     expect(state).toHaveProperty('apps');
     expect(state.apps).toHaveProperty('cms');
-    expect(Object.keys(state.apps.cms)).toHaveLength(12);
+    expect(Object.keys(state.apps.cms)).toHaveLength(13);
   });
 
   it('contains the apimanager state', () => {

--- a/src/state/contents/__tests__/actions.test.js
+++ b/src/state/contents/__tests__/actions.test.js
@@ -10,7 +10,7 @@ import {
   setQuickFilter, setContentType, setGroup, setSort,
   setContentCategoryFilter, checkStatus, checkAccess,
   checkAuthor, setCurrentAuthorShow, setCurrentStatusShow,
-  setCurrentColumnsShow, selectRow, selectAllRows, fetchContents,
+  selectRow, selectAllRows, fetchContents,
   sendDeleteContent, sendPublishContent, setJoinContentCategory,
   resetJoinContentCategories, sendUpdateContents, fetchContentsPaged, setTabSearch,
   sendPublishMultipleContents,
@@ -24,7 +24,7 @@ import {
   SET_QUICK_FILTER, SET_CONTENT_TYPE, SET_GROUP,
   SET_SORT, SET_CONTENT_CATEGORY_FILTER, CHECK_STATUS, CHECK_ACCESS,
   CHECK_AUTHOR, SET_CURRENT_AUTHOR_SHOW, SET_CURRENT_STATUS_SHOW,
-  SET_CURRENT_COLUMNS_SHOW, SELECT_ROW, SELECT_ALL_ROWS, SET_CONTENTS,
+  SELECT_ROW, SELECT_ALL_ROWS, SET_CONTENTS,
   SET_JOIN_CONTENT_CATEGORY, RESET_JOIN_CONTENT_CATEGORIES, SET_TAB_SEARCH, RESET_AUTHOR_STATUS,
   CLEAR_CONTENTS_STATE, SELECT_SINGLE_ROW,
 } from '../types';
@@ -147,12 +147,6 @@ describe('state/contents/actions', () => {
   it('resetAuthorStatus() should return a well formed action', () => {
     const action = resetAuthorStatus();
     expect(action).toHaveProperty('type', RESET_AUTHOR_STATUS);
-  });
-
-  it('setCurrentColumnsShow() should return a well formed action', () => {
-    const action = setCurrentColumnsShow(['created', 'status']);
-    expect(action).toHaveProperty('type', SET_CURRENT_COLUMNS_SHOW);
-    expect(action.payload).toEqual(['created', 'status']);
   });
 
   it('selectRow() should return a well formed action', () => {

--- a/src/state/contents/__tests__/reducer.test.js
+++ b/src/state/contents/__tests__/reducer.test.js
@@ -3,7 +3,7 @@ import {
   setQuickFilter, setContentType, setGroup, setSort,
   setContentCategoryFilter, checkStatus, checkAccess, setContents,
   checkAuthor, setCurrentAuthorShow, setCurrentStatusShow,
-  setCurrentColumnsShow, selectRow, selectAllRows, setJoinContentCategory,
+  selectRow, selectAllRows, setJoinContentCategory,
   resetJoinContentCategories,
   setTabSearch,
 } from 'state/contents/actions';
@@ -127,17 +127,6 @@ describe('state/contents/reducer', () => {
         expect(newState.selectedRows.length).toEqual(2);
         newState = reducer(newState, selectAllRows(false));
         expect(newState.selectedRows.length).toEqual(0);
-      });
-    });
-    describe('after action setCurrentColumnsShow', () => {
-      let newState = reducer({ currentColumnsShow: [] });
-      it('should correctly update currentColumnsShow state field', () => {
-        newState = reducer(newState, setCurrentColumnsShow('column1'));
-        expect(newState.currentColumnsShow).toEqual(['column1']);
-        newState = reducer(newState, setCurrentColumnsShow('column1'));
-        expect(newState.currentColumnsShow).toEqual([]);
-        newState = reducer(newState, setCurrentColumnsShow('name'));
-        expect(newState.currentColumnsShow).toEqual([]);
       });
     });
     describe('after action setContentCategoryFilter', () => {

--- a/src/state/contents/__tests__/selectors.test.js
+++ b/src/state/contents/__tests__/selectors.test.js
@@ -7,7 +7,6 @@ import {
   getAuthorChecked,
   getCurrentAuthorShow,
   getCurrentStatusShow,
-  getCurrentColumnsShow,
   getSortingColumns,
   getSelectedRows,
   getJoiningCategories,
@@ -93,11 +92,6 @@ it('verify getCurrentAuthorShow selector', () => {
 it('verify getCurrentStatusShow selector', () => {
   const status = getCurrentStatusShow(TEST_STATE);
   expect(status).toEqual('approved');
-});
-
-it('verify getCurrentColumnsShow selector', () => {
-  const currentColumns = getCurrentColumnsShow(TEST_STATE);
-  expect(currentColumns).toEqual(['col1', 'col2']);
 });
 
 it('verify getSortingColumns selector', () => {

--- a/src/state/contents/actions.js
+++ b/src/state/contents/actions.js
@@ -16,7 +16,7 @@ import {
 import {
   SET_CONTENTS, SET_QUICK_FILTER, SET_CONTENT_CATEGORY_FILTER,
   CHECK_STATUS, CHECK_ACCESS, CHECK_AUTHOR, SET_CURRENT_AUTHOR_SHOW,
-  SET_CURRENT_STATUS_SHOW, SET_CURRENT_COLUMNS_SHOW, SET_SORT, SET_CONTENT_TYPE, SET_TAB_SEARCH,
+  SET_CURRENT_STATUS_SHOW, SET_SORT, SET_CONTENT_TYPE, SET_TAB_SEARCH,
   SET_GROUP, SELECT_ROW, SELECT_ALL_ROWS, SET_JOIN_CONTENT_CATEGORY, RESET_JOIN_CONTENT_CATEGORIES,
   RESET_AUTHOR_STATUS, SELECT_SINGLE_ROW, CLEAR_CONTENTS_STATE,
 } from 'state/contents/types';
@@ -97,10 +97,6 @@ export const setCurrentStatusShow = status => ({
   payload: status,
 });
 
-export const setCurrentColumnsShow = column => ({
-  type: SET_CURRENT_COLUMNS_SHOW,
-  payload: column,
-});
 export const selectSingleRow = row => ({
   type: SELECT_SINGLE_ROW,
   payload: row,

--- a/src/state/contents/reducer.js
+++ b/src/state/contents/reducer.js
@@ -3,7 +3,6 @@ import {
   SET_QUICK_FILTER, SET_CONTENTS, SET_CONTENT_CATEGORY_FILTER,
   CHECK_STATUS, CHECK_ACCESS, CHECK_AUTHOR, SET_CURRENT_AUTHOR_SHOW,
   SET_CURRENT_STATUS_SHOW,
-  SET_CURRENT_COLUMNS_SHOW,
   SET_SORT,
   SET_CONTENT_TYPE,
   SET_GROUP,
@@ -40,7 +39,6 @@ const defaultState = {
   selectedRows: [],
   currentAuthorShow: 'all',
   currentStatusShow: 'all',
-  currentColumnsShow: ['description', 'firstEditor', 'lastModified', 'typeCode', 'created', 'onLine', 'restriction', 'actions'],
   tabSearchEnabled: true,
 };
 
@@ -158,25 +156,6 @@ const reducer = (state = defaultState, action = {}) => {
       return {
         ...state,
         selectedRows: newSelectedRows,
-      };
-    }
-    case SET_CURRENT_COLUMNS_SHOW: {
-      const code = action.payload;
-      if (code === 'name') {
-        return {
-          ...state,
-        };
-      }
-      let { currentColumnsShow } = state;
-      currentColumnsShow = currentColumnsShow.slice(0);
-      if (currentColumnsShow.includes(code)) {
-        currentColumnsShow = currentColumnsShow.filter(c => c !== code);
-      } else {
-        currentColumnsShow.push(code);
-      }
-      return {
-        ...state,
-        currentColumnsShow,
       };
     }
     case SET_CONTENT_CATEGORY_FILTER: {

--- a/src/state/contents/selectors.js
+++ b/src/state/contents/selectors.js
@@ -57,11 +57,6 @@ export const getCurrentStatusShow = createSelector(
   contents => contents.currentStatusShow,
 );
 
-export const getCurrentColumnsShow = createSelector(
-  getContentsState,
-  contents => contents.currentColumnsShow,
-);
-
 export const getSortingColumns = createSelector(
   getContentsState,
   contents => contents.sortingColumns,

--- a/src/state/contents/types.js
+++ b/src/state/contents/types.js
@@ -6,7 +6,6 @@ export const CHECK_ACCESS = 'cms/contents/check-access';
 export const CHECK_AUTHOR = 'cms/contents/check-author';
 export const SET_CURRENT_AUTHOR_SHOW = 'cms/contents/set-current-author-show';
 export const SET_CURRENT_STATUS_SHOW = 'cms/contents/set-current-status-show';
-export const SET_CURRENT_COLUMNS_SHOW = 'cms/contents/set-current-columns-show';
 export const SET_SORT = 'cms/contents/set-sort';
 export const SET_CONTENT_TYPE = 'cms/contents/set-content-type';
 export const SET_GROUP = 'cms/contents/set-group';

--- a/src/state/rootReducer.js
+++ b/src/state/rootReducer.js
@@ -20,6 +20,7 @@ import pages from 'state/pages/reducer';
 import users from 'state/users/reducer';
 import permissions from 'state/permissions/reducer';
 import versioning from 'state/versioning/reducer';
+import tableColumns from 'state/table-columns/reducer';
 
 export const cms = combineReducers({
   contentTemplate,
@@ -34,6 +35,7 @@ export const cms = combineReducers({
   pages,
   users,
   versioning,
+  tableColumns,
 });
 
 export default combineReducers({

--- a/src/state/table-columns/__tests__/actions.test.js
+++ b/src/state/table-columns/__tests__/actions.test.js
@@ -1,0 +1,10 @@
+import { setCurrentColumnsShow } from 'state/table-columns/actions';
+import { SET_CURRENT_COLUMNS_SHOW } from 'state/table-columns/types';
+
+describe('state/table-columns/actions', () => {
+  it('setCurrentColumnsShow() should return a well formed action', () => {
+    const action = setCurrentColumnsShow(['created', 'status']);
+    expect(action).toHaveProperty('type', SET_CURRENT_COLUMNS_SHOW);
+    expect(action.payload).toEqual(['created', 'status']);
+  });
+});

--- a/src/state/table-columns/__tests__/reducer.test.js
+++ b/src/state/table-columns/__tests__/reducer.test.js
@@ -1,0 +1,19 @@
+import reducer from 'state/table-columns/reducer';
+import { setCurrentColumnsShow } from 'state/table-columns/actions';
+
+describe('state/table-columns/reducer', () => {
+  it('should return an object', () => {
+    const state = reducer();
+    expect(typeof state).toBe('object');
+  });
+
+  describe('after action setCurrentColumnsShow', () => {
+    let newState = reducer();
+    it('should correctly update currentColumnsShow state field', () => {
+      newState = reducer(newState, setCurrentColumnsShow(['column1']));
+      expect(newState.currentColumnsShow).toEqual(['column1']);
+      newState = reducer(newState, setCurrentColumnsShow([]));
+      expect(newState.currentColumnsShow).toEqual([]);
+    });
+  });
+});

--- a/src/state/table-columns/__tests__/selectors.test.js
+++ b/src/state/table-columns/__tests__/selectors.test.js
@@ -1,0 +1,14 @@
+import { getCurrentColumnsShow } from 'state/table-columns/selectors';
+
+const TEST_STATE = {
+  apps: {
+    cms: {
+      tableColumns: { currentColumnsShow: ['col1', 'col2'] },
+    },
+  },
+};
+
+it('verify getCurrentColumnsShow selector', () => {
+  const currentColumns = getCurrentColumnsShow(TEST_STATE);
+  expect(currentColumns).toEqual(['col1', 'col2']);
+});

--- a/src/state/table-columns/actions.js
+++ b/src/state/table-columns/actions.js
@@ -1,0 +1,7 @@
+import { SET_CURRENT_COLUMNS_SHOW } from 'state/table-columns/types';
+
+// eslint-disable-next-line import/prefer-default-export
+export const setCurrentColumnsShow = columns => ({
+  type: SET_CURRENT_COLUMNS_SHOW,
+  payload: columns,
+});

--- a/src/state/table-columns/reducer.js
+++ b/src/state/table-columns/reducer.js
@@ -1,0 +1,16 @@
+import { SET_CURRENT_COLUMNS_SHOW } from 'state/table-columns/types';
+
+const reducer = (state = {}, action = {}) => {
+  switch (action.type) {
+    case SET_CURRENT_COLUMNS_SHOW: {
+      return {
+        ...state,
+        currentColumnsShow: action.payload,
+      };
+    }
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/src/state/table-columns/selectors.js
+++ b/src/state/table-columns/selectors.js
@@ -1,0 +1,9 @@
+import { createSelector } from 'reselect';
+
+export const getTableColumnsState = state => state.apps.cms.tableColumns;
+
+// eslint-disable-next-line import/prefer-default-export
+export const getCurrentColumnsShow = createSelector(
+  getTableColumnsState,
+  tableColumns => tableColumns.currentColumnsShow,
+);

--- a/src/state/table-columns/types.js
+++ b/src/state/table-columns/types.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export const SET_CURRENT_COLUMNS_SHOW = 'cms/table-columns/set-current-columns-show';

--- a/src/ui/common/content/Contents.js
+++ b/src/ui/common/content/Contents.js
@@ -105,13 +105,17 @@ Contents.propTypes = {
   onFilteredSearch: PropTypes.func.isRequired,
   contents: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   contentTypes: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
-  currentColumnsShow: PropTypes.arrayOf(PropTypes.string).isRequired,
+  currentColumnsShow: PropTypes.arrayOf(PropTypes.string),
   onSetContentType: PropTypes.func.isRequired,
   sortingColumns: PropTypes.shape({}).isRequired,
   onSetSort: PropTypes.func.isRequired,
   selectedRows: PropTypes.arrayOf(PropTypes.string).isRequired,
   onAdvancedFilterSearch: PropTypes.func.isRequired,
   onContentSelect: PropTypes.func.isRequired,
+};
+
+Contents.defaultProps = {
+  currentColumnsShow: ['description', 'firstEditor', 'lastModified', 'typeCode', 'created', 'onLine', 'restriction', 'actions'],
 };
 
 export default Contents;

--- a/src/ui/common/content/ContentsContainer.js
+++ b/src/ui/common/content/ContentsContainer.js
@@ -4,18 +4,19 @@ import { withRouter } from 'react-router-dom';
 import { convertToQueryString, FILTER_OPERATORS } from '@entando/utils';
 import {
   setQuickFilter, setCurrentAuthorShow, setCurrentStatusShow,
-  setCurrentColumnsShow, fetchContentsPaged,
-  setContentType, setSort, resetAuthorStatus,
+  fetchContentsPaged, setContentType, setSort, resetAuthorStatus,
 } from 'state/contents/actions';
+import { setCurrentColumnsShow } from 'state/table-columns/actions';
 import { fetchCategoryTree } from 'state/categories/actions';
 import { fetchGroups } from 'state/edit-content/actions';
 import { fetchContentTypeListPaged } from 'state/content-type/actions';
 import {
   getContents, getCurrentQuickFilter, getFilteringCategories,
   getStatusChecked, getAccessChecked, getAuthorChecked, getCurrentAuthorShow,
-  getCurrentStatusShow, getCurrentColumnsShow, getSortingColumns,
+  getCurrentStatusShow, getSortingColumns,
   getSelectedRows,
 } from 'state/contents/selectors';
+import { getCurrentColumnsShow } from 'state/table-columns/selectors';
 import { getPagination } from 'state/pagination/selectors';
 import { getContentTypeList } from 'state/content-type/selectors';
 import { getLoading } from 'state/loading/selectors';
@@ -99,7 +100,7 @@ export const mapDispatchToProps = (dispatch, { status: contentStatus, author: co
     dispatch(fetchContentsPaged(null, null, null, false));
     dispatch(resetAuthorStatus());
   },
-  onSetCurrentColumnsShow: column => dispatch(setCurrentColumnsShow(column)),
+  onSetCurrentColumnsShow: columns => dispatch(setCurrentColumnsShow(columns)),
   onSetContentType: contentType => dispatch(setContentType(contentType)),
   onSetSort: sort => dispatch(setSort(sort)),
 });

--- a/src/ui/contents/Contents.js
+++ b/src/ui/contents/Contents.js
@@ -233,7 +233,7 @@ Contents.propTypes = {
   onCheckAuthor: PropTypes.func.isRequired,
   currentAuthorShow: PropTypes.string.isRequired,
   currentStatusShow: PropTypes.string.isRequired,
-  currentColumnsShow: PropTypes.arrayOf(PropTypes.string).isRequired,
+  currentColumnsShow: PropTypes.arrayOf(PropTypes.string),
   onSetCurrentAuthorShow: PropTypes.func.isRequired,
   onSetCurrentStatusShow: PropTypes.func.isRequired,
   onSetCurrentColumnsShow: PropTypes.func.isRequired,
@@ -261,6 +261,7 @@ Contents.defaultProps = {
   loading: false,
   users: [],
   userPermissions: [],
+  currentColumnsShow: ['description', 'firstEditor', 'lastModified', 'typeCode', 'created', 'onLine', 'restriction', 'actions'],
 };
 
 export default withPermissionValues(Contents);

--- a/src/ui/contents/ContentsContainer.js
+++ b/src/ui/contents/ContentsContainer.js
@@ -5,11 +5,12 @@ import { routeConverter, convertToQueryString, FILTER_OPERATORS } from '@entando
 import { addToast, TOAST_SUCCESS } from '@entando/messages';
 import {
   setQuickFilter, checkStatus, checkAccess, checkAuthor, sendCloneContent,
-  setCurrentAuthorShow, setCurrentStatusShow, setCurrentColumnsShow, fetchContentsPaged,
+  setCurrentAuthorShow, setCurrentStatusShow, fetchContentsPaged,
   setContentType, setGroup, setSort, selectRow, selectAllRows, resetJoinContentCategories,
   setTabSearch,
   resetAuthorStatus, leaveContentsPage,
 } from 'state/contents/actions';
+import { setCurrentColumnsShow } from 'state/table-columns/actions';
 import { fetchCategoryTree } from 'state/categories/actions';
 import { fetchGroups, setNewContentsType, setWorkMode } from 'state/edit-content/actions';
 import { fetchContentTypeListPaged } from 'state/content-type/actions';
@@ -18,9 +19,10 @@ import { fetchUsers } from 'state/users/actions';
 import {
   getContents, getCurrentQuickFilter, getFilteringCategories,
   getStatusChecked, getAccessChecked, getAuthorChecked, getCurrentAuthorShow,
-  getCurrentStatusShow, getCurrentColumnsShow, getSortingColumns,
+  getCurrentStatusShow, getSortingColumns,
   getSelectedRows,
 } from 'state/contents/selectors';
+import { getCurrentColumnsShow } from 'state/table-columns/selectors';
 import { ROUTE_CMS_EDIT_CONTENT, ROUTE_CMS_ADD_CONTENT } from 'app-init/routes';
 import { getPagination } from 'state/pagination/selectors';
 import { getContentTypeList } from 'state/content-type/selectors';

--- a/src/ui/contents/ContentsTabs.js
+++ b/src/ui/contents/ContentsTabs.js
@@ -22,6 +22,16 @@ const ContentTabs = ({
   const csvHeaders = filteredAvailableColumns.map(
     column => Object.assign({}, { label: column.name, key: column.code }),
   );
+  const onClickColumnItem = (code) => {
+    if (code === 'name') return;
+    let newColumns = currentColumnsShow.slice(0);
+    if (newColumns.includes(code)) {
+      newColumns = newColumns.filter(c => c !== code);
+    } else {
+      newColumns.push(code);
+    }
+    onSetCurrentColumnsShow(newColumns);
+  };
   const navItems = (
     <div>
       <Nav bsClass="nav nav-tabs nav-tabs-pf nav-tabs-pf-secondary Contents__main-tab-bar" onSelect={null} style={{ fontSize: '14px' }}>
@@ -104,7 +114,7 @@ const ContentTabs = ({
                   code={code}
                   key={code}
                   active={currentColumnsShow.includes(code)}
-                  onItemClicked={onSetCurrentColumnsShow}
+                  onItemClicked={onClickColumnItem}
                 />
               ),
             )

--- a/src/ui/widget-forms/contents-filter/ContentsFilterModalContainer.js
+++ b/src/ui/widget-forms/contents-filter/ContentsFilterModalContainer.js
@@ -10,21 +10,22 @@ import {
   fetchContentsPaged,
   resetAuthorStatus, selectSingleRow, setContentType,
   setCurrentAuthorShow,
-  setCurrentColumnsShow,
   setCurrentStatusShow, setGroup,
   setQuickFilter, setSort,
   setTabSearch,
   leaveContentsPage,
 } from 'state/contents/actions';
+import { setCurrentColumnsShow } from 'state/table-columns/actions';
 import { getPagination } from 'state/pagination/selectors';
 import { getLoading } from 'state/loading/selectors';
 import {
   getLastSelectedRow,
   getAccessChecked, getAuthorChecked,
-  getContents, getCurrentAuthorShow, getCurrentColumnsShow,
+  getContents, getCurrentAuthorShow,
   getCurrentQuickFilter, getCurrentStatusShow,
   getFilteringCategories, getSelectedRows, getSortingColumns, getStatusChecked,
 } from 'state/contents/selectors';
+import { getCurrentColumnsShow } from 'state/table-columns/selectors';
 import { getLocale } from 'state/locale/selectors';
 import { getGroups } from 'state/edit-content/selectors';
 import { getContentTypeList } from 'state/content-type/selectors';
@@ -124,7 +125,7 @@ export const mapDispatchToProps = dispatch => ({
     dispatch(fetchContentsPaged(null, null, null, false, STATUS_PUBLISHED));
     dispatch(resetAuthorStatus());
   },
-  onSetCurrentColumnsShow: column => dispatch(setCurrentColumnsShow(column)),
+  onSetCurrentColumnsShow: columns => dispatch(setCurrentColumnsShow(columns)),
   onSetContentType: contentType => dispatch(setContentType(contentType)),
   onSetGroup: group => dispatch(setGroup(group)),
   onSetSort: sort => dispatch(setSort(sort)),

--- a/src/ui/widget-forms/contents-filter/ContentsFilterTabs.js
+++ b/src/ui/widget-forms/contents-filter/ContentsFilterTabs.js
@@ -14,6 +14,16 @@ const ContentFilterTabs = ({
   currentStatusShow, onSetCurrentColumnsShow, onSetCurrentStatusShow, onSetCurrentAuthorShow,
   currentUsername, inModal,
 }) => {
+  const onClickColumnItem = (code) => {
+    if (code === 'name') return;
+    let newColumns = currentColumnsShow.slice(0);
+    if (newColumns.includes(code)) {
+      newColumns = newColumns.filter(c => c !== code);
+    } else {
+      newColumns.push(code);
+    }
+    onSetCurrentColumnsShow(newColumns);
+  };
   const navItems = (
     <div>
       {
@@ -51,7 +61,7 @@ const ContentFilterTabs = ({
                   code={code}
                   key={code}
                   active={currentColumnsShow.includes(code)}
-                  onItemClicked={onSetCurrentColumnsShow}
+                  onItemClicked={onClickColumnItem}
                 />
               ),
             )


### PR DESCRIPTION
- Export `table-columns` as separate redux property (took out from `contents` state, as its used several other places too)
- Export `persistData` for usage in `app-builder` to maintain preferred contents table columns list