### PR TITLE
ENG-543 missed default current column array prop

### DIFF
--- a/src/ui/widget-forms/contents-filter/ContentsFilterBrowser.js
+++ b/src/ui/widget-forms/contents-filter/ContentsFilterBrowser.js
@@ -181,7 +181,7 @@ ContentsFilterBrowser.propTypes = {
   onCheckAuthor: PropTypes.func.isRequired,
   currentAuthorShow: PropTypes.string.isRequired,
   currentStatusShow: PropTypes.string.isRequired,
-  currentColumnsShow: PropTypes.arrayOf(PropTypes.string).isRequired,
+  currentColumnsShow: PropTypes.arrayOf(PropTypes.string),
   onDidMount: PropTypes.func.isRequired,
   onSetCurrentAuthorShow: PropTypes.func.isRequired,
   onSetCurrentStatusShow: PropTypes.func.isRequired,
@@ -204,6 +204,7 @@ ContentsFilterBrowser.defaultProps = {
   users: [],
   pickedContents: null,
   onContentPicked: () => {},
+  currentColumnsShow: ['description', 'firstEditor', 'lastModified', 'typeCode', 'created', 'onLine', 'restriction', 'actions'],
 };
 
 


### PR DESCRIPTION
default current columns for content table display of the content table for widget configs was missed after #215 was merged. 