### PR TITLE
ENG-797: CMS/Digital Assets: "Documents" tab shows nothing after long running spinner

### DIFF
--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -310,7 +310,7 @@ export default {
     'cms.assets.list.actions': 'Actions',
     'cms.assets.list.all': 'All',
     'cms.assets.list.image': 'Images',
-    'cms.assets.list.documents': 'Documents',
+    'cms.assets.list.file': 'Documents',
     'cms.assets.list.filterBy': 'Search',
     'cms.assets.list.activeFilters': 'Active Filters',
     'cms.assets.list.clearAll': 'Clear All',

--- a/src/ui/assets/AssetsList.js
+++ b/src/ui/assets/AssetsList.js
@@ -70,7 +70,7 @@ const fileTypes = [
   },
   {
     name: 'Documents',
-    id: 'documents',
+    id: 'file',
   },
 ];
 


### PR DESCRIPTION
The API is expecting the type `file` and we were sending `documents` instead.