### PR TITLE
ENG-996 fix content list widget settings

### DIFF
--- a/src/helpers/__tests__/joinGroups.test.js
+++ b/src/helpers/__tests__/joinGroups.test.js
@@ -1,0 +1,42 @@
+import { parseJoinGroups } from 'helpers/joinGroups';
+
+const JOIN_GROUPS = ['sampleGroup'];
+const EMPTY_ARRAY = [];
+
+describe('helpers/joinGroups', () => {
+  it('array input', () => {
+    expect(parseJoinGroups(JOIN_GROUPS)).toEqual(JOIN_GROUPS);
+  });
+
+  it('stringified array input', () => {
+    expect(parseJoinGroups('["sampleGroup"]')).toEqual(JOIN_GROUPS);
+  });
+
+  it('empty stringified array input', () => {
+    expect(parseJoinGroups('[]')).toEqual(EMPTY_ARRAY);
+  });
+
+  it('empty string input', () => {
+    expect(parseJoinGroups('')).toEqual(EMPTY_ARRAY);
+  });
+
+  it('empty array input', () => {
+    expect(parseJoinGroups([])).toEqual(EMPTY_ARRAY);
+  });
+
+  it('null input', () => {
+    expect(parseJoinGroups(null)).toEqual(EMPTY_ARRAY);
+  });
+
+  it('undefined input', () => {
+    expect(parseJoinGroups(undefined)).toEqual(EMPTY_ARRAY);
+  });
+
+  it('empty object input', () => {
+    expect(parseJoinGroups({})).toEqual(EMPTY_ARRAY);
+  });
+
+  it('object input', () => {
+    expect(parseJoinGroups({ a: 'a', b: 'b' })).toEqual(EMPTY_ARRAY);
+  });
+});

--- a/src/helpers/joinGroups.js
+++ b/src/helpers/joinGroups.js
@@ -1,0 +1,17 @@
+// WORKAROUND because joinGroups can be string. We should investigate why.
+// eslint-disable-next-line import/prefer-default-export
+export const parseJoinGroups = (joinGroups) => {
+  if (Array.isArray(joinGroups)) {
+    return joinGroups;
+  }
+  const isString = typeof joinGroups === 'string' || joinGroups instanceof String;
+  let parsedJoinGroups = [];
+  if (isString) {
+    try {
+      parsedJoinGroups = JSON.parse(joinGroups);
+    } catch (err) {
+      console.warn('Problem parsing join groups string: ', err);
+    }
+  }
+  return parsedJoinGroups;
+};

--- a/src/state/assets/actions.js
+++ b/src/state/assets/actions.js
@@ -36,6 +36,7 @@ import {
   getAssets, createAsset, editAsset, deleteAsset, cloneAsset,
 } from 'api/assets';
 import { getPagination } from 'state/pagination/selectors';
+import { parseJoinGroups } from 'helpers/joinGroups';
 
 export const resetFilteringCategories = () => ({
   type: RESET_FILTERING_CATEGORIES,
@@ -130,7 +131,7 @@ export const fetchAssetsPaged = (
   paginationMetadata = pageDefault,
   assetType = null,
   ownerGroup,
-  joinGroups,
+  joinGroupsToParse,
 ) => (dispatch, getState) => {
   const state = getState();
   const fileType = assetType || getFileType(state);
@@ -155,6 +156,9 @@ export const fetchAssetsPaged = (
   }
 
   const params = compact([convertToQueryString(newFilters).slice(1), typeParams, categoryParams]).join('&');
+
+  const joinGroups = parseJoinGroups(joinGroupsToParse);
+
   const joinGroupsQuery = (joinGroups && joinGroups.length > 0)
     ? joinGroups.reduce((acc, curr, index) => `${acc}&forLinkingWithExtraGroups[${index}]=${curr}`, '') : '';
   return dispatch(fetchAssets(paginationMetadata, `?${params}${ownerGroup ? `&forLinkingWithOwnerGroup=${ownerGroup}` : ''}${joinGroupsQuery}`));

--- a/src/ui/widget-forms/ContentPickerContainer.js
+++ b/src/ui/widget-forms/ContentPickerContainer.js
@@ -6,6 +6,7 @@ import { fetchContentTypeListPaged } from 'state/content-type/actions';
 import { getContentTypeList } from 'state/content-type/selectors';
 import ContentPicker from 'ui/widget-forms/ContentPicker';
 import { getContents } from 'api/contents';
+import { parseJoinGroups } from 'helpers/joinGroups';
 
 const noPaging = { page: 1, pageSize: 0 };
 
@@ -23,10 +24,11 @@ const toFilter = formState => Object.keys(formState).reduce((acc, key) => ({
   operators: {},
 });
 
-const getFilteredContents = (formState, ownerGroup, joinGroups) => {
+const getFilteredContents = (formState, ownerGroup, joinGroupsToParse) => {
   const filter = toFilter(formState);
   const filterParams = convertToQueryString(filter);
   const ownerGroupQuery = ownerGroup ? `&forLinkingWithOwnerGroup=${ownerGroup}` : '';
+  const joinGroups = parseJoinGroups(joinGroupsToParse);
   const joinGroupsQuery = (joinGroups && joinGroups.length > 0)
     ? joinGroups.reduce((acc, curr, index) => `${acc}&forLinkingWithExtraGroups[${index}]=${curr}`, '') : '';
   const contentParams = `${filterParams || '?'}&status=published${ownerGroupQuery}${joinGroupsQuery}`;


### PR DESCRIPTION
Seems that join groups are sometimes returned as a string. At this moment we cannot doing a deep refactor, so I only tried to make the join groups retrieval more robust.
cc @ichalagashvili @jeffgo10 