### PR TITLE
fixing add content screen

### DIFF
--- a/src/ui/edit-content/EditContentForm.js
+++ b/src/ui/edit-content/EditContentForm.js
@@ -149,7 +149,7 @@ export class EditContentFormBody extends React.Component {
     const handleCollapseCategories = val => this.collapseSection('categoriesOpen', val);
     const handleCollapseAttributes = val => this.collapseSection('attributesOpen', val);
     const handleOwnerGroupChange = (e) => {
-      if (e.target.value && workMode === WORK_MODE_EDIT) {
+      if (e.target.value) {
         onSetOwnerGroupDisable(true);
       }
       if (workMode === WORK_MODE_ADD) {


### PR DESCRIPTION
in the previous PR I added `&& workMode === WORK_MODE_EDIT` to not call `onSetOwnerGroupDisable` unnecessarily, but `ownerGroupDisabled` was also being used on `showAllSettings` variable that was responsible to show the other groups after selecting the owner group.

I'm fixing it by removing the extra condition.