### PR TITLE
ENG-1688 Implement Default Content Owner Group and Join Groups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@entando/cms",
-  "version": "0.2.225",
+  "version": "0.2.226",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@entando/cms",
-  "version": "0.2.224",
+  "version": "0.2.225",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/api/__tests__/users.test.js
+++ b/src/api/__tests__/users.test.js
@@ -1,9 +1,12 @@
 import { configEnzymeAdapter } from 'testutils/helpers';
 import {
   getUsers,
+  getUserAuthorities,
 } from 'api/users';
 import {
   USERS,
+  USER,
+  AUTHORITIES,
 } from 'testutils/mocks/users';
 
 import { makeRequest, METHODS } from '@entando/apimanager';
@@ -44,6 +47,24 @@ describe('api/users', () => {
           pageSize: 10,
         },
       );
+    });
+  });
+  describe('getUserAuthorities', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+    it('returns a promise', () => {
+      expect(getUserAuthorities(USER.username)).toBeInstanceOf(Promise);
+    });
+
+    it('makes the correct request with user body', () => {
+      getUserAuthorities(USER.username);
+      expect(makeRequest).toHaveBeenCalledWith(expect.objectContaining({
+        uri: `/api/users/${USER.username}/authorities`,
+        method: METHODS.GET,
+        mockResponse: AUTHORITIES,
+        useAuthentication: true,
+      }));
     });
   });
 });

--- a/src/api/users.js
+++ b/src/api/users.js
@@ -1,5 +1,6 @@
-import { USERS } from 'testutils/mocks/users';
 import { makeRequest, METHODS } from '@entando/apimanager';
+
+import { AUTHORITIES, USERS } from 'testutils/mocks/users';
 
 export const getUsers = (page = { page: 1, pageSize: 10 }, params = '') => (
   makeRequest(
@@ -13,4 +14,9 @@ export const getUsers = (page = { page: 1, pageSize: 10 }, params = '') => (
   )
 );
 
-export default getUsers;
+export const getUserAuthorities = username => makeRequest({
+  uri: `/api/users/${username}/authorities`,
+  method: METHODS.GET,
+  mockResponse: AUTHORITIES,
+  useAuthentication: true,
+});

--- a/src/state/users/__tests__/actions.test.js
+++ b/src/state/users/__tests__/actions.test.js
@@ -4,15 +4,17 @@ import thunk from 'redux-thunk';
 import { mockApi } from 'testutils/helpers';
 
 import {
-  setUsers, fetchUsers,
+  setUsers, fetchUsers, fetchCurrentUserAuthorities,
 } from 'state/users/actions';
 import {
   SET_USERS,
+  SET_SELECTED_USER_AUTHORITIES,
 } from 'state/users/types';
 import { TOGGLE_LOADING } from 'state/loading/types';
 import { SET_PAGE } from 'state/pagination/types';
-import { USERS } from 'testutils/mocks/users';
+import { USERS, USER } from 'testutils/mocks/users';
 import {
+  getUserAuthorities,
   getUsers,
 } from 'api/users';
 
@@ -24,13 +26,14 @@ const mockStore = configureMockStore(middlewares);
 
 jest.mock('api/users', () => ({
   getUsers: jest.fn(mockApi({ payload: [] })),
+  getUserAuthorities: jest.fn(mockApi({ payload: [] })),
 }));
 
 describe('state/users/actions', () => {
   let store;
   beforeEach(() => {
     jest.clearAllMocks();
-    store = mockStore({});
+    store = mockStore({ currentUser: { username: 'admin' } });
   });
 
   describe('users actions ', () => {
@@ -71,6 +74,31 @@ describe('state/users/actions', () => {
             expect(actions[3].type).toEqual(TOGGLE_LOADING);
             done();
           }).catch(done.fail);
+        });
+      });
+
+      describe('fetchCurrentUserAuthorities', () => {
+        it('should dispatch correct actions when it succeeds', (done) => {
+          store.dispatch(fetchCurrentUserAuthorities(USER.username)).then(() => {
+            expect(getUserAuthorities).toHaveBeenCalled();
+            const actions = store.getActions();
+            expect(actions[0]).toHaveProperty('type', SET_SELECTED_USER_AUTHORITIES);
+            done();
+          }).catch(done.fail);
+        });
+
+        it('should dispatch error actions when response has errors', async () => {
+          getUserAuthorities.mockImplementation(mockApi({ errors: true }));
+          return store.dispatch(fetchCurrentUserAuthorities(USER.username)).catch((e) => {
+            expect(getUserAuthorities).toHaveBeenCalled();
+            const actions = store.getActions();
+            expect(actions).toHaveLength(1);
+            expect(actions[0]).toHaveProperty('type', ADD_ERRORS);
+            expect(e).toHaveProperty('errors');
+            e.errors.forEach((error, index) => {
+              expect(error.message).toEqual(actions[0].payload.errors[index]);
+            });
+          });
         });
       });
     });

--- a/src/state/users/__tests__/reducer.test.js
+++ b/src/state/users/__tests__/reducer.test.js
@@ -11,6 +11,7 @@ describe('state/users/reducer', () => {
     expect(typeof state).toBe('object');
     expect(state).toHaveProperty('list', []);
     expect(state).toHaveProperty('map', {});
+    expect(state).toHaveProperty('authorities', []);
   });
 
   describe('after action SET_USERS', () => {

--- a/src/state/users/__tests__/selectors.test.js
+++ b/src/state/users/__tests__/selectors.test.js
@@ -3,6 +3,7 @@ import {
   getUsersIdList,
   getUsersMap,
   getUserList,
+  getSelectedUserAuthorities,
 } from 'state/users/selectors';
 
 jest.mock('state/locale/selectors', () => ({ getLocale: () => ('en') }));
@@ -13,6 +14,7 @@ const TEST_STATE = {
       users: {
         list: [],
         map: {},
+        authorities: [],
       },
     },
   },
@@ -33,5 +35,9 @@ describe('state/users/selectors', () => {
 
   it('verify getUserList selector', () => {
     expect(getUserList(TEST_STATE)).toEqual([]);
+  });
+
+  it('verify getSelectedUserAuthorities selector', () => {
+    expect(getSelectedUserAuthorities(TEST_STATE)).toEqual([]);
   });
 });

--- a/src/state/users/actions.js
+++ b/src/state/users/actions.js
@@ -1,20 +1,28 @@
 import {
   addToast, addErrors, TOAST_ERROR,
 } from '@entando/messages';
+import { getUsername } from '@entando/apimanager';
 
 import {
+  getUserAuthorities,
   getUsers,
 } from 'api/users';
 import { setPage } from 'state/pagination/actions';
 import { NAMESPACE_USERS } from 'state/pagination/const';
 import { toggleLoading } from 'state/loading/actions';
-import { SET_USERS } from 'state/users/types';
-
+import { SET_USERS, SET_SELECTED_USER_AUTHORITIES } from 'state/users/types';
 
 export const setUsers = users => ({
   type: SET_USERS,
   payload: {
     users,
+  },
+});
+
+export const setSelectedUserAuthorities = authorities => ({
+  type: SET_SELECTED_USER_AUTHORITIES,
+  payload: {
+    authorities,
   },
 });
 
@@ -37,3 +45,19 @@ export const fetchUsers = (page = { page: 1, pageSize: 10 }, params = '') => dis
     }).catch(() => {});
   })
 );
+
+export const fetchCurrentUserAuthorities = () => async (dispatch, getState) => {
+  const username = getUsername(getState());
+  try {
+    const response = await getUserAuthorities(username);
+    const json = await response.json();
+    if (response.ok) {
+      dispatch(setSelectedUserAuthorities(json.payload));
+    } else {
+      dispatch(addErrors(json.errors.map(e => e.message)));
+      json.errors.forEach(err => dispatch(addToast(err.message, TOAST_ERROR)));
+    }
+  } catch (e) {
+    // do nothing
+  }
+};

--- a/src/state/users/reducer.js
+++ b/src/state/users/reducer.js
@@ -1,5 +1,5 @@
 import { combineReducers } from 'redux';
-import { SET_USERS } from 'state/users/types';
+import { SET_SELECTED_USER_AUTHORITIES, SET_USERS } from 'state/users/types';
 
 const toMap = array => array.reduce((acc, user) => {
   acc[user.username] = user;
@@ -26,7 +26,20 @@ const userMap = (state = {}, action = {}) => {
   }
 };
 
+const authorities = (state = [], action = {}) => {
+  switch (action.type) {
+    case SET_SELECTED_USER_AUTHORITIES: {
+      return action.payload.authorities;
+    }
+
+    default: {
+      return state;
+    }
+  }
+};
+
 export default combineReducers({
   list,
   map: userMap,
+  authorities,
 });

--- a/src/state/users/selectors.js
+++ b/src/state/users/selectors.js
@@ -3,6 +3,7 @@ import { createSelector } from 'reselect';
 export const getUsers = state => state.apps.cms.users;
 export const getUsersIdList = state => state.apps.cms.users.list;
 export const getUsersMap = state => state.apps.cms.users.map;
+export const getSelectedUserAuthorities = state => state.apps.cms.users.authorities;
 
 export const getUserList = createSelector(
   [getUsersMap, getUsersIdList],

--- a/src/state/users/types.js
+++ b/src/state/users/types.js
@@ -1,2 +1,2 @@
-// eslint-disable-next-line import/prefer-default-export
 export const SET_USERS = 'users/set-users';
+export const SET_SELECTED_USER_AUTHORITIES = 'users/set-selected-authorities';

--- a/src/testutils/mocks/editContent.js
+++ b/src/testutils/mocks/editContent.js
@@ -37,6 +37,11 @@ export const ADD_CONTENT_OPENED_OK = {
     version: '0.0',
   },
   enableTranslationWarning: true,
+  initialValues: {
+    mainGroup: undefined,
+    groups: undefined,
+    contentType: undefined,
+  },
 };
 
 export const GET_CONTENT_RESPONSE_OK = {

--- a/src/testutils/mocks/users.js
+++ b/src/testutils/mocks/users.js
@@ -1,3 +1,18 @@
+export const USER = {
+  username: 'login',
+  registration: '2018-01-08 00:00:00',
+  lastLogin: '2018-01-08 00:00:00',
+  lastPasswordChange: '2018-01-08 00:00:00',
+  status: 'active',
+  passwordChangeRequired: true,
+  profileAttributes: {
+    fullName: '',
+    email: '',
+  },
+  accountNotExpired: true,
+  credentialsNotExpired: true,
+};
+
 export const USERS = [
   {
     username: 'admin',

--- a/src/ui/add-content/__tests__/AddContentFormContainer.test.js
+++ b/src/ui/add-content/__tests__/AddContentFormContainer.test.js
@@ -3,6 +3,15 @@ import { configEnzymeAdapter } from 'testutils/helpers';
 import { mapStateToProps, mapDispatchToProps } from 'ui/add-content/AddContentFormContainer';
 import { ADD_CONTENT_OPENED_OK } from 'testutils/mocks/editContent';
 
+jest.mock('state/user-preferences/selectors', () => ({
+  getUserPreferences: jest.fn(() => ({})),
+  getTranslationWarning: jest.fn(() => true),
+}));
+
+jest.mock('state/users/selectors', () => ({
+  getSelectedUserAuthorities: jest.fn(),
+}));
+
 const TEST_STATE = {
   apps: {
     cms: {
@@ -39,7 +48,7 @@ configEnzymeAdapter();
 
 describe('AddContentFormContainer connection to redux', () => {
   it('maps editContent properties from state to AddContentForm', () => {
-    expect(mapStateToProps(TEST_STATE)).toEqual(ADD_CONTENT_OPENED_OK);
+    expect(mapStateToProps(TEST_STATE, { match: {} })).toEqual(ADD_CONTENT_OPENED_OK);
   });
 
   it('verify that onDidMount and onSetOwnerGroupDisable are defined and called in mapDispatchToProps', () => {

--- a/src/ui/edit-content/EditContentForm.js
+++ b/src/ui/edit-content/EditContentForm.js
@@ -44,8 +44,6 @@ const messages = defineMessages({
   },
 });
 
-const defaultOwnerGroup = '';
-
 const fieldFocus = (el, addDelay) => {
   const focusEl = el.current;
   if (!focusEl) {
@@ -77,7 +75,7 @@ export class EditContentFormBody extends React.Component {
 
   componentDidMount() {
     const {
-      initialize, onDidMount, match: { params = {} },
+      onDidMount, match: { params = {} },
       onIncompleteData,
     } = this.props;
     const { id: contentId, contentType } = params;
@@ -85,7 +83,6 @@ export class EditContentFormBody extends React.Component {
     if (contentType == null && contentId == null) return onIncompleteData();
     // if contentId from params is null, it means we are creating a new content
     if (contentId == null) {
-      initialize({ mainGroup: defaultOwnerGroup, contentType });
       fieldFocus(this.ownerGroupInput);
     }
     return onDidMount(fetchContentParams);

--- a/src/ui/edit-content/content-attributes/AttributeFields.js
+++ b/src/ui/edit-content/content-attributes/AttributeFields.js
@@ -171,7 +171,12 @@ const AttributeFields = ({
       });
     });
     reInitializeForm('editcontentform', {
-      ...content, attributes: atts, contentType: typeCode, mainGroup, joinGroups,
+      ...content,
+      attributes: atts,
+      contentType: typeCode,
+      mainGroup,
+      joinGroups,
+      groups: joinGroups,
     });
   }
 


### PR DESCRIPTION
* Sets the default content owner group to a value derived from the user preferences. If there's no value, this sets the content owner group to be the group in which the user has the admin role (extracted from the user authorities).
* Sets the default content join groups to an array of values derived from the user preferences.