### PR TITLE
ENG-2198: preventing unnecessary component rerender

### DIFF
--- a/src/ui/assets/AssetsList.js
+++ b/src/ui/assets/AssetsList.js
@@ -55,6 +55,16 @@ class AssetsList extends Component {
     window.addEventListener('resize', this.updateWindowDimensions);
   }
 
+  shouldComponentUpdate(nextProps, nextState) {
+    // redux-form is making this component to rerender many times unnecessarely
+    // this will ensure the component render will only be triggered when really necessary
+    if (JSON.stringify(nextProps) === JSON.stringify(this.props)
+    && JSON.stringify(nextState) === JSON.stringify(this.state)) {
+      return false;
+    }
+    return true;
+  }
+
   componentWillUnmount() {
     window.removeEventListener('resize', this.updateWindowDimensions);
   }


### PR DESCRIPTION
The redux-form actions being triggered at search(and anything else on this screen) is making the assets component to rerender(and refetching the images from a cache). This issue should be the main reason for bad performance described in this ticket, I couldn't find anything else as I don't have that many data on my local env.

Issue without the fix:

![2021-04-28 10 51 22](https://user-images.githubusercontent.com/11444682/116437109-79758a00-a823-11eb-8e12-126a6d988282.gif)

after the fix:

![2021-04-28 11 04 12](https://user-images.githubusercontent.com/11444682/116437156-86927900-a823-11eb-8c1a-5ae0a5714a23.gif)





