### PR TITLE
ENG-2302 resolve issue on removing active filter tag above asset list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@entando/cms",
-  "version": "0.2.244",
+  "version": "0.2.245",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@entando/cms",
-  "version": "0.2.245",
+  "version": "0.2.244",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/ui/assets/AssetsListContainer.js
+++ b/src/ui/assets/AssetsListContainer.js
@@ -40,6 +40,13 @@ import { getColumnOrder } from 'state/table-column-order/selectors';
 import { DELETE_ASSET_MODAL_ID } from 'ui/assets/DeleteAssetModal';
 import { CLONE_ASSET_MODAL_ID } from 'ui/assets/modals/clone-asset/CloneAssetModal';
 
+const toggleCategoryInArray = (category, categories) => {
+  if (categories.filter(cat => cat.code === category.code).length === 0) {
+    return [...categories, category];
+  }
+  return categories.filter(c => c.code !== category.code);
+};
+
 export const mapStateToProps = (state) => {
   const {
     page, lastPage, totalItems, pageSize,
@@ -92,7 +99,9 @@ export const mapDispatchToProps = (dispatch, ownProps) => ({
   onRemoveActiveFilter: (category, filteringCategories) => {
     const { ownerGroup, joinGroups } = ownProps;
     dispatch(removeActiveFilter(category));
-    dispatch(setAssetCategoryFilter(category));
+    dispatch(setAssetCategoryFilter(
+      toggleCategoryInArray(category, filteringCategories),
+    ));
     const newFilters = filteringCategories.filter(c => c.code !== category.code).map(c => c.code);
     const filtSend = newFilters.length ? {
       categories: makeFilter(

--- a/src/ui/categories/filter/CategoryTreeFilterContainer.js
+++ b/src/ui/categories/filter/CategoryTreeFilterContainer.js
@@ -12,7 +12,7 @@ import {
 import { getCategoryTree } from 'state/categories/selectors';
 
 const toggleCategoryInArray = (category, categories) => {
-  if (!categories.filter(cat => cat.code === category.code).length !== 0) {
+  if (categories.filter(cat => cat.code === category.code).length === 0) {
     return [...categories, category];
   }
   return categories.filter(c => c.code !== category.code);

--- a/src/ui/categories/filter/CategoryTypeaheadFilter.js
+++ b/src/ui/categories/filter/CategoryTypeaheadFilter.js
@@ -40,8 +40,6 @@ const CategoryTypeaheadFilter = ({
       });
       filterParams.push(extraParams.toString());
 
-      // const typeParams = assetType === 'all' ? '' : `type=${assetType}`;
-
       onApplyFilteredSearch(selected, `?${filterParams.join('&')}`);
     }
   };


### PR DESCRIPTION
toggle categories in the array functionality (in asset filter reducer) has been recently removed from the previous PRs and this particular control above the assets list which is active filter chip set is presumably relying on the toggle function reducer. this PR resolves it by using a special toggle in an array function before going to the reducer