### PR TITLE
ENG-2496 resolve issue on involuntary close modal in single content widget config

### DIFF
--- a/src/ui/common/modal/GenericModal.js
+++ b/src/ui/common/modal/GenericModal.js
@@ -4,30 +4,38 @@ import { Modal, Icon, Button } from 'patternfly-react';
 import { FormattedMessage } from 'react-intl';
 
 const GenericModal = ({
-  visibleModal, modalId, modalClassName, onCloseModal, children, buttons, modalFooter, modalTitle,
+  visibleModal,
+  modalId,
+  modalClassName,
+  onOpenModal,
+  onCloseModal,
+  children,
+  buttons,
+  modalFooter,
+  modalTitle,
 }) => {
   const footer = modalFooter || (
     <Modal.Footer>
-      <Button
-        bsStyle="default"
-        className="btn-cancel"
-        onClick={onCloseModal}
-      >
-        <FormattedMessage id="app.cancel" />
+      <Button bsStyle="default" className="btn-cancel GenericModal__cancel" onClick={onCloseModal}>
+        <FormattedMessage id={buttons.length ? 'cms.label.cancel' : 'cms.label.okay'} />
       </Button>
-      {buttons.map(button => (<Button {...button.props} key={button.props.id} />))}
+      {buttons.map(button => (
+        <Button {...button.props} key={button.props.id} />
+      ))}
     </Modal.Footer>
   );
 
   return (
     <Modal
       show={visibleModal === modalId}
+      onEnter={onOpenModal}
       onHide={onCloseModal}
       id={modalId}
       dialogClassName={modalClassName}
     >
       <Modal.Header>
         <button
+          type="button"
           className="close"
           onClick={onCloseModal}
           aria-hidden="true"
@@ -37,9 +45,7 @@ const GenericModal = ({
         </button>
         {modalTitle}
       </Modal.Header>
-      <Modal.Body>
-        {children}
-      </Modal.Body>
+      <Modal.Body>{children}</Modal.Body>
       {footer}
     </Modal>
   );
@@ -50,6 +56,7 @@ GenericModal.propTypes = {
   modalClassName: PropTypes.string,
   modalId: PropTypes.string.isRequired,
   onCloseModal: PropTypes.func.isRequired,
+  onOpenModal: PropTypes.func,
   modalTitle: PropTypes.node,
   children: PropTypes.node.isRequired,
   modalFooter: PropTypes.node,
@@ -62,6 +69,7 @@ GenericModal.defaultProps = {
   modalTitle: '',
   modalFooter: '',
   buttons: [],
+  onOpenModal: () => {},
 };
 
 export default GenericModal;

--- a/src/ui/common/modal/GenericModal.js
+++ b/src/ui/common/modal/GenericModal.js
@@ -4,38 +4,30 @@ import { Modal, Icon, Button } from 'patternfly-react';
 import { FormattedMessage } from 'react-intl';
 
 const GenericModal = ({
-  visibleModal,
-  modalId,
-  modalClassName,
-  onOpenModal,
-  onCloseModal,
-  children,
-  buttons,
-  modalFooter,
-  modalTitle,
+  visibleModal, modalId, modalClassName, onCloseModal, children, buttons, modalFooter, modalTitle,
 }) => {
   const footer = modalFooter || (
     <Modal.Footer>
-      <Button bsStyle="default" className="btn-cancel GenericModal__cancel" onClick={onCloseModal}>
-        <FormattedMessage id={buttons.length ? 'cms.label.cancel' : 'cms.label.okay'} />
+      <Button
+        bsStyle="default"
+        className="btn-cancel"
+        onClick={onCloseModal}
+      >
+        <FormattedMessage id="app.cancel" />
       </Button>
-      {buttons.map(button => (
-        <Button {...button.props} key={button.props.id} />
-      ))}
+      {buttons.map(button => (<Button {...button.props} key={button.props.id} />))}
     </Modal.Footer>
   );
 
   return (
     <Modal
       show={visibleModal === modalId}
-      onEnter={onOpenModal}
       onHide={onCloseModal}
       id={modalId}
       dialogClassName={modalClassName}
     >
       <Modal.Header>
         <button
-          type="button"
           className="close"
           onClick={onCloseModal}
           aria-hidden="true"
@@ -45,7 +37,9 @@ const GenericModal = ({
         </button>
         {modalTitle}
       </Modal.Header>
-      <Modal.Body>{children}</Modal.Body>
+      <Modal.Body>
+        {children}
+      </Modal.Body>
       {footer}
     </Modal>
   );
@@ -56,7 +50,6 @@ GenericModal.propTypes = {
   modalClassName: PropTypes.string,
   modalId: PropTypes.string.isRequired,
   onCloseModal: PropTypes.func.isRequired,
-  onOpenModal: PropTypes.func,
   modalTitle: PropTypes.node,
   children: PropTypes.node.isRequired,
   modalFooter: PropTypes.node,
@@ -69,7 +62,6 @@ GenericModal.defaultProps = {
   modalTitle: '',
   modalFooter: '',
   buttons: [],
-  onOpenModal: () => {},
 };
 
 export default GenericModal;

--- a/src/ui/common/modal/GenericModalContainer.js
+++ b/src/ui/common/modal/GenericModalContainer.js
@@ -7,8 +7,14 @@ export const mapStateToProps = state => ({
   visibleModal: getVisibleModal(state),
 });
 
-export const mapDispatchToProps = dispatch => ({
-  onCloseModal: () => dispatch(setVisibleModal('')),
+export const mapDispatchToProps = (dispatch, ownProps) => ({
+  onCloseModal: () => {
+    dispatch(setVisibleModal(''));
+    const { modalCloseCleanup } = ownProps || {};
+    if (modalCloseCleanup) {
+      modalCloseCleanup();
+    }
+  },
 });
 
 const GenericModalContainer = connect(

--- a/src/ui/widget-forms/publish-single-content-config/SingleContentConfigContainer.js
+++ b/src/ui/widget-forms/publish-single-content-config/SingleContentConfigContainer.js
@@ -111,11 +111,13 @@ export const mapDispatchToProps = (dispatch, ownProps) => {
       }
       dispatch(setVisibleModal(ContentsFilterModalID));
     },
-    onSelectContent: (selectContent) => {
+    onSelectContent: (selectContent, andCloseModal = true) => {
       dispatch(change(formToUse, putPrefixField('contentId'), selectContent.id));
       dispatch(change(formToUse, putPrefixField('contentDescription'), selectContent.description));
-      dispatch(setVisibleModal(''));
-      dispatch(setAppTourLastStep(21));
+      if (andCloseModal) {
+        dispatch(setVisibleModal(''));
+        dispatch(setAppTourLastStep(21));
+      }
     },
     onClickAddContent: (contentType) => {
       const {

--- a/src/ui/widget-forms/publish-single-content-config/SingleContentConfigFormBody.js
+++ b/src/ui/widget-forms/publish-single-content-config/SingleContentConfigFormBody.js
@@ -66,18 +66,18 @@ export class SingleContentConfigFormBody extends PureComponent {
     const json = await response.json();
     if (response.ok) {
       const selectedContent = json.payload;
-      this.handleContentSelect(selectedContent);
+      this.handleContentSelect(selectedContent, false);
     }
   }
 
-  handleContentSelect(selectedContent) {
+  handleContentSelect(selectedContent, closeModal = true) {
     const { onSelectContent, loadContentTypeDetails } = this.props;
     const contentId = get(selectedContent, 'contentId', get(selectedContent, 'id', ''));
     const typeCodeSub = contentId ? contentId.substr(0, 3) : '';
     const contentTypeCode = get(selectedContent, 'typeCode', typeCodeSub);
     loadContentTypeDetails(contentTypeCode);
     this.setState({ selectedContent });
-    onSelectContent(selectedContent);
+    onSelectContent(selectedContent, closeModal);
   }
 
   enclosedWithForm(fields) {


### PR DESCRIPTION
I found out this issue when I was working on cypress test on editing widget config for single content. when changing content in an existing single content widget, modal automatically closes before it could even load the list of contents to choose from. Also amended the recent change for generic modal component from app-builder.