### PR TITLE
ENG-2608 Fix content link validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@entando/cms",
-  "version": "0.2.281",
+  "version": "0.2.282",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/helpers/attrValidation.js
+++ b/src/helpers/attrValidation.js
@@ -187,14 +187,16 @@ export const getAttrValidators = (validationRules) => {
 };
 
 export const linkValidate = memoize((langCode, required = false) => input => (
-  ((!required && !input) || (!(input && input.value && (
-    (required && !input.value.symbolicDestination)
-      || (input.value.symbolicDestination && input.value.symbolicDestination !== EMPTY_SYMBOLIC_DEST
-        && !input.values[langCode])))
-  ))
+  (!required && (
+    !input || (!input.value || (!input.value.symbolicDestination || (
+      input.value.symbolicDestination && input.values[langCode]
+    ))))) || (
+    required && input && input.value && input.value.symbolicDestination
+    && input.values[langCode] && input.value.symbolicDestination !== EMPTY_SYMBOLIC_DEST
+  )
     ? undefined
     : (<FormattedMessage id="validateForm.required" />)
-));
+), (...args) => JSON.stringify(args));
 
 export const listRequired = value => (
   !value || !value.length ? <FormattedMessage id="validateForm.required" /> : undefined

--- a/src/ui/edit-content/content-attributes/AttributeField.js
+++ b/src/ui/edit-content/content-attributes/AttributeField.js
@@ -56,6 +56,7 @@ const AttributeField = ({
   locale,
   isSub,
   openedAtStart,
+  defaultLang,
 }) => {
   const {
     type,
@@ -147,7 +148,7 @@ const AttributeField = ({
     case TYPE_LINK:
       AttributeFieldComp = LinkAttributeField;
       actualName = name;
-      validate.push(linkValidate(langCode, mandatory));
+      validate.push(linkValidate(defaultLang, mandatory));
       break;
     case TYPE_MONOTEXT:
       AttributeFieldComp = MonotextAttributeField;
@@ -204,6 +205,7 @@ AttributeField.propTypes = {
   locale: PropTypes.string,
   isSub: PropTypes.bool,
   openedAtStart: PropTypes.bool,
+  defaultLang: PropTypes.string.isRequired,
 };
 
 AttributeField.defaultProps = {

--- a/src/ui/edit-content/content-attributes/AttributeFields.js
+++ b/src/ui/edit-content/content-attributes/AttributeFields.js
@@ -20,6 +20,7 @@ import {
   TYPE_BOOLEAN,
   TYPE_CHECKBOX,
   TYPE_THREESTATE,
+  TYPE_LINK,
 } from 'state/content-type/const';
 import { getDateTimeObjFromStr } from 'helpers/attrUtils';
 import { listRequired, compositeOneOfExists } from 'helpers/attrValidation';
@@ -73,7 +74,7 @@ const renderField = (
   // the attribute should not be mandatory for non-default languages
   const newAttribute = {
     ...attribute,
-    mandatory: defaultAndMandatory,
+    mandatory: type === TYPE_LINK ? mandatory : defaultAndMandatory,
   };
 
   const validate = [];
@@ -107,6 +108,7 @@ const renderField = (
           locale={locale}
           attribute={newAttribute}
           langCode={langCode}
+          defaultLang={defaultLang}
           labelSize={0}
           hasLabel={false}
           mainGroup={mainGroup}


### PR DESCRIPTION
* Fixes validation logic
* Adds resolver function as 2nd arg to `memoize()` in order to have a proper cache key
* Passes `defaultLang` into `linkValidate()` to avoid the field validation being overridden by another with a different `langCode`